### PR TITLE
Use Ruff instead of Black+isort+Flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,21 +5,16 @@
 #   $ pre-commit install
 exclude: '^docs/code-comparisons/'  # skip the code comparisons directory
 repos:
--   repo: https://github.com/ambv/black
-    rev: 24.8.0
-    hooks:
-    - id: black
-      args: [--line-length=100, --exclude=docs/*]
-#- repo: https://github.com/astral-sh/ruff-pre-commit
-#  # Ruff version.
-#  rev: v0.5.6
-#  hooks:
-#    # Run the linter.
-#    - id: ruff
-#      args: [ --fix ]
-#    # Run the formatter.
-#    - id: ruff-format
-#      args: [ --diff ]
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.5.7
+  hooks:
+    # Run the linter.
+    - id: ruff
+      args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
+      args: [ --diff ]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
-      args: [ --diff ]
+#      args: [ --diff ]  # Use for previewing changes
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,16 +25,6 @@ repos:
     -   id: requirements-txt-fixer
     # valid python file
     -   id: check-ast
-# isort python package import sorting
--   repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-    -   id: isort
-        args: ["--profile", "black",
-               "--line-length=100",
-               "--skip=docs/",
-               "--known-local-folder", "tests",
-               "-p", "hamilton"]
 -   repo: https://github.com/pycqa/flake8
     rev: 7.1.1
     hooks:

--- a/README-DOCS.md
+++ b/README-DOCS.md
@@ -7,7 +7,7 @@ Instructions for managing documentation on read the docs.
 To build locally, you need to run the following -- make sure you're in the root of the repo:
 
 ```bash
-pip install -r requirements-docs.txt
+pip install .[docs]
 ```
 and then one of the following to build and view the documents:
 ```bash

--- a/contrib/hamilton/contrib/dagworks/sphinx_doc_chunking/__init__.py
+++ b/contrib/hamilton/contrib/dagworks/sphinx_doc_chunking/__init__.py
@@ -152,7 +152,6 @@ def collect_chunked_url_text(url_result: Collect[dict]) -> list:
 if __name__ == "__main__":
     # code here for quickly testing the build of the code here.
     import __main__ as sphinx_doc_chunking
-
     from hamilton import driver
     from hamilton.execution import executors
 

--- a/contrib/hamilton/contrib/dagworks/text_summarization/__init__.py
+++ b/contrib/hamilton/contrib/dagworks/text_summarization/__init__.py
@@ -8,11 +8,11 @@ logger = logging.getLogger(__name__)
 from hamilton import contrib
 
 with contrib.catch_import_errors(__name__, __file__, logger):
+    import litellm
     import tiktoken
     from pypdf import PdfReader
     from tenacity import retry, stop_after_attempt, wait_random_exponential
     from tqdm import tqdm
-    import litellm
 
 from hamilton.function_modifiers import config
 

--- a/contrib/hamilton/contrib/user/skrawcz/air_quality_analysis/__init__.py
+++ b/contrib/hamilton/contrib/user/skrawcz/air_quality_analysis/__init__.py
@@ -257,7 +257,6 @@ def p_value(t_value: np.ndarray, dof: int) -> float:
 
 if __name__ == "__main__":
     import __main__ as analysis_flow
-
     from hamilton import base, driver
 
     # let's create a dictionary result -- since we want to get a few things from execution for inspection

--- a/contrib/hamilton/contrib/user/skrawcz/customize_embeddings/__init__.py
+++ b/contrib/hamilton/contrib/user/skrawcz/customize_embeddings/__init__.py
@@ -43,10 +43,10 @@ with contrib.catch_import_errors(__name__, __file__, logger):
     import plotly.express as px  # for plots
     import plotly.graph_objs as go  # for plot object type
     import requests
+    import torch  # for matrix optimization
     from sklearn.model_selection import (
         train_test_split,
     )  # for splitting train & test data
-    import torch  # for matrix optimization
     from tenacity import retry, stop_after_attempt, wait_random_exponential
 
 from hamilton.function_modifiers import (

--- a/contrib/hamilton/contrib/user/skrawcz/customize_embeddings/__init__.py
+++ b/contrib/hamilton/contrib/user/skrawcz/customize_embeddings/__init__.py
@@ -134,7 +134,8 @@ processed_dataset_schema = pa.DataFrameSchema(
 @config.when(source="snli")
 @check_output(schema=processed_dataset_schema, importance="fail")
 def processed_local_dataset__snli(
-    snli_dataset: pd.DataFrame, num_pairs_to_embed: int = 1000  # 1000 is arbitrary
+    snli_dataset: pd.DataFrame,
+    num_pairs_to_embed: int = 1000,  # 1000 is arbitrary
 ) -> pd.DataFrame:
     """Processes a raw dataset into a dataframe of text pairs to embed; and check that it matches the schema.
 

--- a/contrib/hamilton/contrib/user/skrawcz/fine_tuning/__init__.py
+++ b/contrib/hamilton/contrib/user/skrawcz/fine_tuning/__init__.py
@@ -9,10 +9,11 @@ from hamilton import contrib
 
 with contrib.catch_import_errors(__name__, __file__, logger):
     import evaluate
-    from datasets.combine import DatasetType
-    from datasets import Dataset, concatenate_datasets
     import numpy as np
     import pandas as pd
+    import torch
+    from datasets import Dataset, concatenate_datasets
+    from datasets.combine import DatasetType
     from peft import (
         LoraConfig,
         PeftConfig,
@@ -22,15 +23,14 @@ with contrib.catch_import_errors(__name__, __file__, logger):
         prepare_model_for_int8_training,
     )
     from sklearn.model_selection import train_test_split
-    import torch
     from tqdm import tqdm
     from transformers import (
         AutoModelForSeq2SeqLM,
         AutoTokenizer,
         DataCollatorForSeq2Seq,
+        PreTrainedTokenizerBase,
         Seq2SeqTrainer,
         Seq2SeqTrainingArguments,
-        PreTrainedTokenizerBase,
     )
 
 from hamilton.function_modifiers import extract_fields

--- a/contrib/hamilton/contrib/user/zilto/lancedb_vdb/__init__.py
+++ b/contrib/hamilton/contrib/user/zilto/lancedb_vdb/__init__.py
@@ -7,10 +7,10 @@ logger = logging.getLogger(__name__)
 from hamilton import contrib
 
 with contrib.catch_import_errors(__name__, __file__, logger):
-    import pyarrow as pa
     import lancedb
     import numpy as np
     import pandas as pd
+    import pyarrow as pa
     from lancedb.pydantic import LanceModel
 
 from hamilton.function_modifiers import tag

--- a/contrib/hamilton/contrib/user/zilto/webscraper/__init__.py
+++ b/contrib/hamilton/contrib/user/zilto/webscraper/__init__.py
@@ -6,9 +6,9 @@ logger = logging.getLogger(__name__)
 from hamilton import contrib
 
 with contrib.catch_import_errors(__name__, __file__, logger):
-    from bs4 import BeautifulSoup
     import lxml  # noqa: F401
     import requests
+    from bs4 import BeautifulSoup
     from tenacity import retry, stop_after_attempt, wait_random_exponential
 
 import dataclasses

--- a/contrib/hamilton/contrib/user/zilto/xgboost_optuna/__init__.py
+++ b/contrib/hamilton/contrib/user/zilto/xgboost_optuna/__init__.py
@@ -8,10 +8,10 @@ from hamilton import contrib
 
 with contrib.catch_import_errors(__name__, __file__, logger):
     import numpy as np
+    import optuna
     import pandas as pd
     import xgboost
-    import optuna
-    from optuna.distributions import IntDistribution, FloatDistribution
+    from optuna.distributions import FloatDistribution, IntDistribution
     from sklearn.metrics import accuracy_score, mean_squared_error
     from sklearn.model_selection import KFold, StratifiedKFold
 

--- a/dev_tools/language_server/hamilton_lsp/server.py
+++ b/dev_tools/language_server/hamilton_lsp/server.py
@@ -2,7 +2,6 @@ import inspect
 import re
 from typing import Type
 
-from hamilton_lsp import __version__
 from lsprotocol.types import (
     TEXT_DOCUMENT_COMPLETION,
     TEXT_DOCUMENT_DID_CHANGE,
@@ -28,6 +27,7 @@ from pygls.server import LanguageServer
 from hamilton import ad_hoc_utils
 from hamilton.graph import FunctionGraph, create_graphviz_graph
 from hamilton.graph_types import HamiltonGraph
+from hamilton_lsp import __version__
 
 
 def _type_to_string(type_: Type):

--- a/dev_tools/language_server/tests/conftest.py
+++ b/dev_tools/language_server/tests/conftest.py
@@ -17,6 +17,7 @@
 # limitations under the License.                                           #
 ############################################################################
 import pytest
+
 from hamilton_lsp.server import HamiltonLanguageServer, register_server_features
 
 from .ls_setup import NativeClientServer

--- a/developer_setup.md
+++ b/developer_setup.md
@@ -26,10 +26,7 @@ Install the project's dependencies in your preferred method for managing python 
 python -m venv ./venv
 . ./venv/bin/activate
 
-pip install \
-    -r ./requirements.txt \
-    -r ./requirements-dev.txt \
-    -r ./requirements-test.txt
+pip install .[dev,test]
 ```
 
 Set up `pre-commit`, which will run some lightweight formatting and linting tasks on every commit.

--- a/examples/LLM_Workflows/RAG_document_extract_chunk_embed/pipeline.py
+++ b/examples/LLM_Workflows/RAG_document_extract_chunk_embed/pipeline.py
@@ -159,7 +159,6 @@ def store(
 
 if __name__ == "__main__":
     import __main__ as doc_pipeline
-
     from hamilton import driver
 
     # create the driver

--- a/examples/LLM_Workflows/langchain_comparison/hamilton_anthropic.py
+++ b/examples/LLM_Workflows/langchain_comparison/hamilton_anthropic.py
@@ -38,7 +38,6 @@ def joke_response__anthropic(llm_client: anthropic.Anthropic, joke_prompt: str) 
 
 if __name__ == "__main__":
     import hamilton_invoke_anthropic
-
     from hamilton import driver
 
     dr = (

--- a/examples/LLM_Workflows/langchain_comparison/hamilton_async.py
+++ b/examples/LLM_Workflows/langchain_comparison/hamilton_async.py
@@ -28,7 +28,6 @@ if __name__ == "__main__":
     import asyncio
 
     import hamilton_async
-
     from hamilton import base
     from hamilton.experimental import h_async
 

--- a/examples/LLM_Workflows/langchain_comparison/hamilton_batch.py
+++ b/examples/LLM_Workflows/langchain_comparison/hamilton_batch.py
@@ -38,7 +38,6 @@ def joke_responses(joke_response: Collect[str]) -> List[str]:
 
 if __name__ == "__main__":
     import hamilton_batch
-
     from hamilton import driver
 
     dr = (

--- a/examples/LLM_Workflows/langchain_comparison/hamilton_completion.py
+++ b/examples/LLM_Workflows/langchain_comparison/hamilton_completion.py
@@ -38,7 +38,6 @@ def joke_response__chat(llm_client: openai.OpenAI, joke_messages: List[dict]) ->
 
 if __name__ == "__main__":
     import hamilton_completion
-
     from hamilton import driver
 
     dr = (

--- a/examples/LLM_Workflows/langchain_comparison/hamilton_fallbacks.py
+++ b/examples/LLM_Workflows/langchain_comparison/hamilton_fallbacks.py
@@ -1,5 +1,4 @@
 import hamilton_anthropic
-
 from hamilton import driver
 
 anthropic_driver = (

--- a/examples/LLM_Workflows/langchain_comparison/hamilton_invoke.py
+++ b/examples/LLM_Workflows/langchain_comparison/hamilton_invoke.py
@@ -26,7 +26,6 @@ def joke_response(llm_client: openai.OpenAI, joke_messages: List[dict]) -> str:
 
 if __name__ == "__main__":
     import hamilton_invoke
-
     from hamilton import driver
 
     dr = driver.Builder().with_modules(hamilton_invoke).build()

--- a/examples/LLM_Workflows/langchain_comparison/hamilton_logging.py
+++ b/examples/LLM_Workflows/langchain_comparison/hamilton_logging.py
@@ -1,6 +1,5 @@
 # run.py
 import hamilton_anthropic
-
 from hamilton import driver, lifecycle
 
 dr = (

--- a/examples/LLM_Workflows/langchain_comparison/hamilton_streamed.py
+++ b/examples/LLM_Workflows/langchain_comparison/hamilton_streamed.py
@@ -28,7 +28,6 @@ def joke_response(llm_client: openai.OpenAI, joke_messages: List[dict]) -> Itera
 
 if __name__ == "__main__":
     import hamilton_streaming
-
     from hamilton import driver
 
     dr = driver.Builder().with_modules(hamilton_streaming).build()

--- a/examples/LLM_Workflows/modular_llm_stack/qdrant_module.py
+++ b/examples/LLM_Workflows/modular_llm_stack/qdrant_module.py
@@ -11,7 +11,6 @@ def initialize_vector_db_indices(
     class_name: str,
     embedding_dimension: int,
 ) -> bool:
-
     if client_vector_db.collection_exists(class_name):
         client_vector_db.delete_collection(class_name)
 

--- a/examples/LLM_Workflows/scraping_and_chunking/run.py
+++ b/examples/LLM_Workflows/scraping_and_chunking/run.py
@@ -13,7 +13,6 @@ from hamilton import driver
 from hamilton.execution import executors
 
 if __name__ == "__main__":
-
     dr = (
         driver.Builder()
         .with_modules(doc_pipeline)

--- a/examples/LLM_Workflows/scraping_and_chunking/spark/spark_pipeline.py
+++ b/examples/LLM_Workflows/scraping_and_chunking/spark/spark_pipeline.py
@@ -70,7 +70,6 @@ def chunked_url_text(urls_from_sitemap: ps.DataFrame) -> ps.DataFrame:
 
 
 if __name__ == "__main__":
-
     import spark_pipeline
 
     from hamilton import driver

--- a/examples/airflow/dags/hamilton/hamilton_how_to_dag.py
+++ b/examples/airflow/dags/hamilton/hamilton_how_to_dag.py
@@ -1,4 +1,4 @@
-""" This file shows different usage pattern to integrate Hamilton with Apache Airflow
+"""This file shows different usage pattern to integrate Hamilton with Apache Airflow
 
 For the purpose of this example, we will read and write data from the Airflow
 installation location (${AIRFLOW_HOME}/plugins/data).

--- a/examples/async/fastapi_example.py
+++ b/examples/async/fastapi_example.py
@@ -5,9 +5,9 @@ import aiohttp
 import async_module
 import fastapi
 from aiohttp import client_exceptions
-from hamilton_sdk import adapters
 
 from hamilton import async_driver
+from hamilton_sdk import adapters
 
 logger = logging.getLogger(__name__)
 

--- a/examples/aws/glue/processing.py
+++ b/examples/aws/glue/processing.py
@@ -4,9 +4,9 @@ import pandas as pd
 
 # awsglue is installed in the AWS Glue worker environment
 from awsglue.utils import getResolvedOptions
-from hamilton_functions import functions
 
 from hamilton import driver
+from hamilton_functions import functions
 
 if __name__ == "__main__":
     args = getResolvedOptions(sys.argv, ["input-table", "output-table"])

--- a/examples/aws/glue/processing.py
+++ b/examples/aws/glue/processing.py
@@ -9,7 +9,6 @@ from hamilton_functions import functions
 from hamilton import driver
 
 if __name__ == "__main__":
-
     args = getResolvedOptions(sys.argv, ["input-table", "output-table"])
 
     df = pd.read_csv(args["input_table"])

--- a/examples/aws/lambda/app/lambda_handler.py
+++ b/examples/aws/lambda/app/lambda_handler.py
@@ -6,7 +6,6 @@ from . import functions
 
 
 def lambda_handler(event, context):
-
     df = pd.DataFrame(**event["body"])
 
     dr = driver.Driver({}, functions)

--- a/examples/aws/sagemaker/processing.py
+++ b/examples/aws/sagemaker/processing.py
@@ -4,7 +4,6 @@ from app import functions
 from hamilton import driver
 
 if __name__ == "__main__":
-
     df = pd.read_csv("/opt/ml/processing/input/data/input_table.csv")
 
     dr = driver.Driver({}, functions)

--- a/examples/dagster/dagster_code/tutorial/resources/__init__.py
+++ b/examples/dagster/dagster_code/tutorial/resources/__init__.py
@@ -130,6 +130,7 @@ class DataGeneratorResource(ConfigurableResource):
             from dagster import Definitions, asset
             from dagster_data_generator import DataGeneratorResource, DataGeneratorConfig
 
+
             @asset
             def my_table(data_gen: DataGeneratorConfig):
                 return data_gen.get_signups()

--- a/examples/dagster/hamilton_code/mock_api.py
+++ b/examples/dagster/hamilton_code/mock_api.py
@@ -131,6 +131,7 @@ class DataGeneratorResource(ConfigurableResource):
             from dagster import Definitions, asset
             from dagster_data_generator import DataGeneratorResource, DataGeneratorConfig
 
+
             @asset
             def my_table(data_gen: DataGeneratorConfig):
                 return data_gen.get_signups()

--- a/examples/dbt/python_transforms/feature_transforms.py
+++ b/examples/dbt/python_transforms/feature_transforms.py
@@ -8,8 +8,10 @@ from typing import Set
 import pandas as pd
 
 # from sklearn.preprocessing import OneHotEncoder
-from sklearn import impute  # import KNNImputer
-from sklearn import preprocessing
+from sklearn import (
+    impute,  # import KNNImputer
+    preprocessing,
+)
 
 from hamilton.function_modifiers import check_output, config
 

--- a/examples/due_date_probabilities/probability_estimation.py
+++ b/examples/due_date_probabilities/probability_estimation.py
@@ -98,9 +98,7 @@ def raw_data() -> str:
 43 weeks, 3 days	99.8%	0.1%	0.1%
 43 weeks, 4 days	99.9%	0.1%	< 0.1%
 43 weeks, 5 days	99.9%	< 0.1%	< 0.1%
-43 weeks, 6 days	> 99.9%	< 0.1%""".replace(
-            "weeks\t", "weeks, 0 days "
-        )
+43 weeks, 6 days	> 99.9%	< 0.1%""".replace("weeks\t", "weeks, 0 days ")
         .replace("\t", " ")
         .split("\n")
     )

--- a/examples/feature_engineering/feature_engineering_multiple_contexts/scenario_1/fastapi_server.py
+++ b/examples/feature_engineering/feature_engineering_multiple_contexts/scenario_1/fastapi_server.py
@@ -1,4 +1,4 @@
-""""
+""" "
 This is a simple example of a FastAPI server that uses Hamilton on the request
 path to transform the data into features, and then uses a fake model to make
 a prediction.

--- a/examples/feature_engineering/feature_engineering_multiple_contexts/scenario_2/fastapi_server.py
+++ b/examples/feature_engineering/feature_engineering_multiple_contexts/scenario_2/fastapi_server.py
@@ -1,4 +1,4 @@
-""""
+""" "
 This is a simple example of a FastAPI server that uses Hamilton on the request
 path to transform the data into features, and then uses a fake model to make
 a prediction.

--- a/examples/hamilton-tutorials/mpg-translation/mpg_pipeline.py
+++ b/examples/hamilton-tutorials/mpg-translation/mpg_pipeline.py
@@ -17,7 +17,6 @@ from sklearn.preprocessing import StandardScaler  # noqa: F401
 
 if __name__ == "__main__":
     import __main__
-
     from hamilton import driver
 
     dr = driver.Builder().with_modules(__main__).build()

--- a/examples/hamilton-tutorials/mpg-translation/mpg_pipeline_advanced_target.py
+++ b/examples/hamilton-tutorials/mpg-translation/mpg_pipeline_advanced_target.py
@@ -88,7 +88,6 @@ def evaluated_model(
 
 if __name__ == "__main__":
     import __main__
-
     from hamilton import driver
 
     dr = driver.Builder().with_modules(__main__).build()

--- a/examples/hamilton-tutorials/mpg-translation/mpg_pipeline_target.py
+++ b/examples/hamilton-tutorials/mpg-translation/mpg_pipeline_target.py
@@ -85,7 +85,6 @@ def evaluated_model(linear_model: dict, data_sets: dict) -> dict:
 
 if __name__ == "__main__":
     import __main__
-
     from hamilton import driver
 
     dr = driver.Builder().with_modules(__main__).build()

--- a/examples/hamilton_ui/run.py
+++ b/examples/hamilton_ui/run.py
@@ -1,10 +1,10 @@
 import click
 from components import feature_transforms, iris_loader, models
-from hamilton_sdk import adapters
 
 from hamilton import driver as h_driver
 from hamilton.io.materialization import to
 from hamilton.lifecycle import PrintLnHook
+from hamilton_sdk import adapters
 
 
 @click.command()

--- a/examples/kedro/hamilton-code/tests/test_dataflow.py
+++ b/examples/kedro/hamilton-code/tests/test_dataflow.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import pytest
-from hamilton_code import data_science
 
 from hamilton import driver
+from hamilton_code import data_science
 
 
 @pytest.fixture

--- a/examples/kedro/kedro-code/pyproject.toml
+++ b/examples/kedro/kedro-code/pyproject.toml
@@ -57,7 +57,7 @@ docstring-code-format = true
 [tool.ruff]
 line-length = 88
 show-fixes = true
-select = [
+lint.select = [
     "F",   # Pyflakes
     "W",   # pycodestyle
     "E",   # pycodestyle
@@ -66,4 +66,4 @@ select = [
     "PL",  # Pylint
     "T201", # Print Statement
 ]
-ignore = ["E501"]  # Ruff format takes care of line-too-long
+lint.ignore = ["E501"]  # Ruff format takes care of line-too-long

--- a/examples/kedro/kedro-code/src/kedro_code/__init__.py
+++ b/examples/kedro/kedro-code/src/kedro_code/__init__.py
@@ -1,4 +1,3 @@
-"""kedro_code
-"""
+"""kedro_code"""
 
 __version__ = "0.1"

--- a/examples/kedro/kedro-code/src/kedro_code/pipelines/data_processing/nodes.py
+++ b/examples/kedro/kedro-code/src/kedro_code/pipelines/data_processing/nodes.py
@@ -61,6 +61,8 @@ def create_model_input_table(
     """
     rated_shuttles = shuttles.merge(reviews, left_on="id", right_on="shuttle_id")
     rated_shuttles = rated_shuttles.drop("id", axis=1)
-    model_input_table = rated_shuttles.merge(companies, left_on="company_id", right_on="id")
+    model_input_table = rated_shuttles.merge(
+        companies, left_on="company_id", right_on="id"
+    )
     model_input_table = model_input_table.dropna()
     return model_input_table

--- a/examples/kedro/kedro-code/src/kedro_code/pipelines/data_science/nodes.py
+++ b/examples/kedro/kedro-code/src/kedro_code/pipelines/data_science/nodes.py
@@ -39,7 +39,9 @@ def train_model(X_train: pd.DataFrame, y_train: pd.Series) -> LinearRegression:
     return regressor
 
 
-def evaluate_model(regressor: LinearRegression, X_test: pd.DataFrame, y_test: pd.Series) -> None:
+def evaluate_model(
+    regressor: LinearRegression, X_test: pd.DataFrame, y_test: pd.Series
+) -> None:
     """Calculates and logs the coefficient of determination.
 
     Args:

--- a/examples/materialization/datasaver_dataloader_example/run.py
+++ b/examples/materialization/datasaver_dataloader_example/run.py
@@ -1,7 +1,7 @@
 import simple_etl
-from hamilton_sdk import adapters
 
 from hamilton import driver
+from hamilton_sdk import adapters
 
 tracker = adapters.HamiltonTracker(
     project_id=7,  # modify this as needed

--- a/examples/model_examples/time-series/run.py
+++ b/examples/model_examples/time-series/run.py
@@ -1,13 +1,16 @@
 import logging
 import sys
 import time
+from typing import TYPE_CHECKING
 
 import data_loaders
 import model_pipeline
-import pandas as pd
 import transforms
 
 from hamilton import driver
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 logger = logging.getLogger(__name__)
 

--- a/examples/narwhals/example.py
+++ b/examples/narwhals/example.py
@@ -36,7 +36,6 @@ def group_by_mean(df: nw.DataFrame) -> nw.DataFrame:
 
 if __name__ == "__main__":
     import __main__ as example
-
     from hamilton import base, driver
     from hamilton.plugins import h_narwhals, h_polars
 

--- a/examples/reverse_etl/upload_timesheet.py
+++ b/examples/reverse_etl/upload_timesheet.py
@@ -310,9 +310,9 @@ def command_output(
 
 
 if __name__ == "__main__":
-    import __main__
     import pandas as pd
 
+    import __main__
     from hamilton import driver
 
     # build dataflow

--- a/examples/schema/dataflow.py
+++ b/examples/schema/dataflow.py
@@ -27,7 +27,6 @@ if __name__ == "__main__":
     import json
 
     import __main__
-
     from hamilton import driver
     from hamilton.plugins import h_schema
 

--- a/examples/schema/multi_dataflow.py
+++ b/examples/schema/multi_dataflow.py
@@ -51,7 +51,6 @@ if __name__ == "__main__":
     import json
 
     import __main__
-
     from hamilton import driver
     from hamilton.plugins import h_schema
 

--- a/examples/scikit-learn/run.py
+++ b/examples/scikit-learn/run.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import importlib
 import logging
-from types import ModuleType
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List
 
 import numpy as np
 import pandas as pd
@@ -13,6 +12,9 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.utils.validation import check_array, check_is_fitted
 
 from hamilton import base, driver, log_setup
+
+if TYPE_CHECKING:
+    from types import ModuleType
 
 
 class HamiltonTransformer(BaseEstimator, TransformerMixin):

--- a/hamilton/async_driver.py
+++ b/hamilton/async_driver.py
@@ -434,14 +434,14 @@ class Builder(driver.Builder):
     .. code-block:: python
 
         from hamilton_sdk import tracker
+
         tracker_async = adapters.AsyncHamiltonTracker(
             project_id=1,
             username="elijah",
             dag_name="async_tracker",
         )
         dr = (
-            await async_driver
-            .Builder()
+            await async_driver.Builder()
             .with_modules(async_module)
             .with_adapters(tracking_async)
             .build()

--- a/hamilton/base.py
+++ b/hamilton/base.py
@@ -44,9 +44,10 @@ class DictResult(ResultMixin):
     .. code-block:: python
 
         from hamilton import base, driver
+
         dict_builder = base.DictResult()
         adapter = base.SimplePythonGraphAdapter(dict_builder)
-        dr =  driver.Driver(config, *modules, adapter=adapter)
+        dr = driver.Driver(config, *modules, adapter=adapter)
         dict_result = dr.execute([...], inputs=...)
 
     Note, if you just want the dict result + the SimplePythonGraphAdapter, you can use the
@@ -90,7 +91,7 @@ class PandasDataFrameResult(ResultMixin):
 
     @staticmethod
     def pandas_index_types(
-        outputs: Dict[str, Any]
+        outputs: Dict[str, Any],
     ) -> Tuple[Dict[str, List[str]], Dict[str, List[str]], Dict[str, List[str]]]:
         """This function creates three dictionaries according to whether there is an index type or not.
 
@@ -332,6 +333,7 @@ class NumpyMatrixResult(ResultMixin):
     .. code-block:: python
 
         from hamilton import base, driver
+
         adapter = base.SimplePythonGraphAdapter(base.NumpyMatrixResult())
         dr = driver.Driver(config, *modules, adapter=adapter)
         numpy_matrix = dr.execute([...], inputs=...)

--- a/hamilton/cli/logic.py
+++ b/hamilton/cli/logic.py
@@ -155,7 +155,6 @@ def diff_nodes_against_functions(
     nodes_origin_version = set(nodes_version.values())
     # iterate over origin functions from source code
     for origin_name, origin_version in origins_version.items():
-
         # if origin_version not found in nodes_version, the
         # origin function is not used by the built Driver
         if origin_version not in nodes_origin_version:

--- a/hamilton/dataflows/__init__.py
+++ b/hamilton/dataflows/__init__.py
@@ -337,11 +337,11 @@ def inspect(dataflow: str, user: str = None, version: str = "latest") -> Inspect
     }
 
     with open(os.path.join(local_file_path, "requirements.txt"), "r") as f:
-        file_contents = [line.strip() for line in f.readlines()]
+        file_contents = [line.strip() for line in f]
         info["python_dependencies"] = file_contents
 
     with open(os.path.join(local_file_path, "valid_configs.jsonl"), "r") as f:
-        file_contents = [line.strip() for line in f.readlines()]
+        file_contents = [line.strip() for line in f]
         info["configurations"] = file_contents
     return InspectResult(**info)
 
@@ -411,7 +411,7 @@ def inspect_module(module: ModuleType) -> InspectModuleResult:
         info["python_dependencies"] = file_contents
 
     with open(os.path.join(local_file_path, "valid_configs.jsonl"), "r") as f:
-        file_contents = [json.loads(s) for s in f.readlines()]
+        file_contents = [json.loads(s) for s in f]
         info["configurations"] = file_contents
 
     dr = driver.Driver(info["configurations"][0], module)

--- a/hamilton/dataflows/__init__.py
+++ b/hamilton/dataflows/__init__.py
@@ -628,6 +628,7 @@ def copy(
         dataflow.copy(NAME_OF_DATAFLOW, destination_path="PATH_TO_DIRECTORY")
         # copy from the installed library
         from hamilton.contrib.user.NAME_OF_USER import NAME_OF_DATAFLOW
+
         dataflow.copy(NAME_OF_DATAFLOW, destination_path="PATH_TO_DIRECTORY")
 
     :param dataflow: the module to copy.

--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -248,12 +248,13 @@ class Driver:
 
         # 2. we need to tell hamilton where to load function definitions from
         import my_functions
+
         # or programmatically (e.g. you can script module loading)
-        module_name = 'my_functions'
+        module_name = "my_functions"
         my_functions = importlib.import_module(module_name)
 
         # 3. Determine the return type -- default is a pandas.DataFrame.
-        adapter = base.SimplePythonDataFrameGraphAdapter() # See GraphAdapter docs for more details.
+        adapter = base.SimplePythonDataFrameGraphAdapter()  # See GraphAdapter docs for more details.
 
         # These all feed into creating the driver & thus DAG.
         dr = driver.Driver(config, module, adapter=adapter)
@@ -1398,6 +1399,7 @@ class Driver:
              from hamilton import driver, base
              from hamilton.function_modifiers import source
              from hamilton.io.materialization import to
+
              dr = driver.Driver(my_module, {})
              # foo, bar are pd.Series
              metadata, result = dr.Materialize(
@@ -1409,10 +1411,10 @@ class Driver:
                      path=source("save_path"),
                      id="foo_bar_csv",
                      dependencies=["foo", "bar"],
-                     combine=base.PandasDataFrameResult()
+                     combine=base.PandasDataFrameResult(),
                  ),
                  additional_vars=["foo", "bar"],
-                 inputs={"save_path" : "./output.csv"}
+                 inputs={"save_path": "./output.csv"},
              )
 
         While this is a contrived example, you could imagine something more powerful. Say, for
@@ -1446,17 +1448,21 @@ class Driver:
             from hamilton import driver, base
             from hamilton.function_modifiers import source
             from hamilton.io.materialization import to
+
             dr = driver.Driver(my_module, {})
             metadata, _ = dr.Materialize(
                 from_.model_registry(
                     target="input_model",
-                    query_tags={"training_date" : ..., model_version: ...}, # query based on run_id, model_version
+                    query_tags={
+                        "training_date": ...,
+                        model_version: ...,
+                    },  # query based on run_id, model_version
                 ),
                 to.csv(
                     path=source("save_path"),
                     id="save_inference_data",
                     dependencies=["inference_data"],
-                )
+                ),
             )
 
         Note that the "from" extractor has an interesting property -- it effectively functions as overrides. This
@@ -1923,9 +1929,8 @@ if __name__ == "__main__":
         module,
     )
     df = dr.execute(
-        ["date_index", "some_column"]
+        ["date_index", "some_column"],
         # ,overrides={'DATE': pd.Series(0)}
-        ,
         display_graph=False,
     )
     print(df)

--- a/hamilton/experimental/h_cache.py
+++ b/hamilton/experimental/h_cache.py
@@ -221,12 +221,11 @@ class CachingGraphAdapter(SimplePythonGraphAdapter):
     .. code-block:: python
 
         @write_json.register(T)
-        def write_json_pd1(data: T, filepath: str, name: str) -> None:
-            ...
+        def write_json_pd1(data: T, filepath: str, name: str) -> None: ...
+
 
         @read_json.register(T)
-        def read_json_dict(data: T, filepath: str) -> T:
-            ...
+        def read_json_dict(data: T, filepath: str) -> T: ...
 
     Usage
     -----
@@ -240,15 +239,15 @@ class CachingGraphAdapter(SimplePythonGraphAdapter):
         import pandas as pd
         from hamilton.function_modifiers import tag
 
-        def data_a() -> pd.DataFrame:
-            ...
+
+        def data_a() -> pd.DataFrame: ...
+
 
         @tag(cache="parquet")
-        def data_b() -> pd.DataFrame:
-            ...
+        def data_b() -> pd.DataFrame: ...
 
-        def transformed(data_a: pd.DataFrame, data_b: pd.DataFrame) -> pd.DataFrame:
-            ...
+
+        def transformed(data_a: pd.DataFrame, data_b: pd.DataFrame) -> pd.DataFrame: ...
 
     Notice that `data_b` is configured to be cached in a parquet file.
 

--- a/hamilton/experimental/h_databackends.py
+++ b/hamilton/experimental/h_databackends.py
@@ -11,9 +11,11 @@ It is powerful when used with `@functools.singledispatch`
             raise NotImplementedError(f"Type {type(df)} is currently unsupported.")
         return from_dataframe(df, allow_copy=True).schema
 
+
     @get_arrow_schema.register
     def _(df: h_databackends.AbstractPandasDataFrame) -> pyarrow.Schema:
         return pyarrow.Table.from_pandas(df).schema
+
 
     @get_arrow_schema.register
     def _(df: h_databackends.AbstractIbisDataFrame) -> pyarrow.Schema:

--- a/hamilton/function_modifiers/adapters.py
+++ b/hamilton/function_modifiers/adapters.py
@@ -631,7 +631,7 @@ class save_to(metaclass=save_to__meta__):
     .. code-block:: python
 
         dr = driver.Driver(my_module)
-        output = dr.execute(['final_output'], {'raw_data_path': '/path/my_data.json'})
+        output = dr.execute(["final_output"], {"raw_data_path": "/path/my_data.json"})
 
     You would *just* get the final result, and nothing would be saved.
 
@@ -640,7 +640,7 @@ class save_to(metaclass=save_to__meta__):
     .. code-block:: python
 
         dr = driver.Driver(my_module)
-        output = dr.execute(['data_save_output'], {'raw_data_path': '/path/my_data.json'})
+        output = dr.execute(["data_save_output"], {"raw_data_path": "/path/my_data.json"})
 
     You would get a dictionary of metadata (about the saving output), and the final result would
     be saved to a path.
@@ -649,7 +649,7 @@ class save_to(metaclass=save_to__meta__):
 
     .. code-block:: python
 
-        @save_to.json(path=value('/path/my_data.json'), output_name_="data_save_output")
+        @save_to.json(path=value("/path/my_data.json"), output_name_="data_save_output")
         def final_output(data: dict, valid_keys: List[str]) -> dict:
             return [item for item in data if item in valid_keys]
 
@@ -712,8 +712,9 @@ class dataloader(NodeCreator):
         import pandas as pd
         from hamilton.function_modifiers import dataloader
 
+
         @dataloader()  # you need ()
-        def load_json_data(json_path: str = 'data/my_data.json') -> tuple[pd.DataFrame, dict]:
+        def load_json_data(json_path: str = "data/my_data.json") -> tuple[pd.DataFrame, dict]:
             '''Loads a dataframe from a JSON file.
 
             :return: A tuple containing two dictionaries:
@@ -724,7 +725,7 @@ class dataloader(NodeCreator):
             data = pd.read_json(json_path)
 
             # Metadata about the loading process
-            metadata = {'source': json_path, 'format': 'json'}
+            metadata = {"source": json_path, "format": "json"}
 
             return data, metadata
 
@@ -819,8 +820,9 @@ class datasaver(NodeCreator):
         import pandas as pd
         from hamilton.function_modifiers import datasaver
 
-        @datasaver() # you need ()
-        def save_json_data(data: pd.DataFrame, json_path: str = 'data/my_saved_data.json') -> dict:
+
+        @datasaver()  # you need ()
+        def save_json_data(data: pd.DataFrame, json_path: str = "data/my_saved_data.json") -> dict:
             '''Saves data to a JSON file and returns metadata about the saving process.
 
             :param data: The data to save.
@@ -828,11 +830,11 @@ class datasaver(NodeCreator):
             :return: metadata about what was saved.
             '''
             # Save the data
-            with open(json_path, 'w') as file:
+            with open(json_path, "w") as file:
                 data.to_json(json_path)
 
             # Metadata about the saving process
-            metadata = {'destination': json_path, 'format': 'json'}
+            metadata = {"destination": json_path, "format": "json"}
 
             return metadata
 

--- a/hamilton/function_modifiers/delayed.py
+++ b/hamilton/function_modifiers/delayed.py
@@ -75,12 +75,13 @@ class resolve(DynamicResolver):
 
         from hamilton.function_modifiers import resolve, ResolveAt
 
+
         @resolve(
             when=ResolveAt.CONFIG_AVAILABLE,
             decorate_with=lambda first_series_sum, second_series_sum: parameterize_sources(
                 series_sum_1={"s1": first_series_sum[0], "s2": second_series_sum[1]},
                 series_sum_2={"s1": second_series_sum[1], "s2": second_series_sum[2]},
-            )
+            ),
         )
         def summation(s1: pd.Series, s2: pd.Series) -> pd.Series:
             return s1 + s2
@@ -163,6 +164,7 @@ class resolve_from_config(resolve):
     .. code-block:: python
 
         from hamilton.function_modifiers import resolve, ResolveAt
+
 
         @resolve_from_config(
             decorate_with=lambda first_series_sum, second_series_sum: parameterize_sources(

--- a/hamilton/function_modifiers/macros.py
+++ b/hamilton/function_modifiers/macros.py
@@ -531,7 +531,9 @@ class Applicable:
         return (
             (default_namespace,)
             if self.namespace is ...
-            else (self.namespace,) if self.namespace is not None else ()
+            else (self.namespace,)
+            if self.namespace is not None
+            else ()
         )
 
     def bind_function_args(
@@ -603,14 +605,18 @@ class pipe(base.NodeInjector):
 
         from hamilton.function_modifiers import step, pipe, value, source
 
+
         def _add_one(x: int) -> int:
             return x + 1
+
 
         def _sum(x: int, y: int) -> int:
             return x + y
 
-        def _multiply(x: int, y: int, z: int=10) -> int:
+
+        def _multiply(x: int, y: int, z: int = 10) -> int:
             return x * y * z
+
 
         @pipe(
             step(_add_one),
@@ -624,8 +630,8 @@ class pipe(base.NodeInjector):
     .. code-block:: python
         :name: Equivalent example with no @pipe, nested
 
-        upstream_int = ... # result from upstream
-        upstream_node_to_multiply = ... # result from upstream
+        upstream_int = ...  # result from upstream
+        upstream_node_to_multiply = ...  # result from upstream
 
         output = final_result(
             _multiply(
@@ -643,8 +649,8 @@ class pipe(base.NodeInjector):
     .. code-block:: python
         :name: Equivalent example with no @pipe, procedural
 
-        upstream_int = ... # result from upstream
-        upstream_node_to_multiply = ... # result from upstream
+        upstream_int = ...  # result from upstream
+        upstream_node_to_multiply = ...  # result from upstream
 
         one_added = _add_one(upstream_int)
         multiplied = _multiply(one_added, y=2)
@@ -713,8 +719,8 @@ class pipe(base.NodeInjector):
 
 
             @pipe(
-                step(_add_one).named("a", namespace="foo"), # foo.a
-                step(_add_two, y=source("upstream_node")).named("b", namespace=...), # final_result.b
+                step(_add_one).named("a", namespace="foo"),  # foo.a
+                step(_add_two, y=source("upstream_node")).named("b", namespace=...),  # final_result.b
             )
             def final_result(upstream_int: int) -> int:
                 return upstream_int

--- a/hamilton/function_modifiers/metadata.py
+++ b/hamilton/function_modifiers/metadata.py
@@ -285,7 +285,6 @@ class schema:
 
 
 class RayRemote(tag):
-
     def __init__(self, **options: Union[int, Dict[str, int]]):
         """Initializes RayRemote. See docs for `@ray_remote_options` for more details."""
 
@@ -313,7 +312,6 @@ def ray_remote_options(**kwargs: Union[int, Dict[str, int]]) -> RayRemote:
             num_gpus=1,
             resources={"my_custom_resource": 1},
         )
-        def example() -> pd.DataFrame:
-            ...
+        def example() -> pd.DataFrame: ...
     """
     return RayRemote(**kwargs)

--- a/hamilton/function_modifiers/recursive.py
+++ b/hamilton/function_modifiers/recursive.py
@@ -229,7 +229,7 @@ class subdag(base.NodeCreator):
 
     @staticmethod
     def collect_functions(
-        load_from: Union[Collection[ModuleType], Collection[Callable]]
+        load_from: Union[Collection[ModuleType], Collection[Callable]],
     ) -> List[Callable]:
         """Utility function to collect functions from a list of callables/modules.
 

--- a/hamilton/graph_types.py
+++ b/hamilton/graph_types.py
@@ -162,9 +162,7 @@ class HamiltonNode:
         try:
             # return hash of first function. It could be that others are Hamilton framework code.
             return hash_source_code(self.originating_functions[0], strip=True)
-        except (
-            OSError
-        ):  # TODO -- ensure we can get the node hash in a databricks environment when using jupyter magic
+        except OSError:  # TODO -- ensure we can get the node hash in a databricks environment when using jupyter magic
             logger.warning(
                 f"Failed to hash source code for node {self.name}. Certain environments (such as databricks) do not allow it."
                 " In this case, version will be None."

--- a/hamilton/io/materialization.py
+++ b/hamilton/io/materialization.py
@@ -92,7 +92,7 @@ class extractor_meta__(type):
 
 
 def process_kwargs(
-    data_saver_kwargs: Dict[str, Union[Any, SingleDependency]]
+    data_saver_kwargs: Dict[str, Union[Any, SingleDependency]],
 ) -> Dict[str, SingleDependency]:
     """Processes raw strings from the user, converting them into dependency specs.
     This goes according to the following rules.

--- a/hamilton/lifecycle/default.py
+++ b/hamilton/lifecycle/default.py
@@ -598,14 +598,18 @@ class GracefulErrorAdapter(NodeExecutionMethod):
             class DoNotProceed(Exception):
                 pass
 
+
             def wont_proceed() -> int:
                 raise DoNotProceed()
+
 
             def will_proceed() -> int:
                 return 1
 
+
             def never_reached(wont_proceed: int) -> int:
                 return 1  # this should not be reached
+
 
             dr = (
                 driver.Builder()
@@ -618,7 +622,9 @@ class GracefulErrorAdapter(NodeExecutionMethod):
                 )
                 .build()
             )
-            dr.execute(["will_proceed", "never_reached"])  # will return {'will_proceed': 1, 'never_reached': None}
+            dr.execute(
+                ["will_proceed", "never_reached"]
+            )  # will return {'will_proceed': 1, 'never_reached': None}
 
         Note you can customize the error you want it to fail on and the sentinel value to use in place of a node's result if it fails.
 
@@ -636,17 +642,21 @@ class GracefulErrorAdapter(NodeExecutionMethod):
             class DoNotProceed(Exception):
                 pass
 
+
             def start_point() -> Parallelizable[int]:
                 for i in range(5):
                     if i == 3:
                         raise DoNotProceed()
                     yield i
 
+
             def inner(start_point: int) -> int:
                 return start_point
 
+
             def gather(inner: Collect[int]) -> list[int]:
                 return inner
+
 
             dr = (
                 driver.Builder()
@@ -748,6 +758,7 @@ class NoEdgeAndInputTypeChecking(EdgeConnectionHook):
 
         from hamilton import driver
         from hamilton.lifecycle import NoEdgeAndInputTypeChecking
+
         dr = driver.Builder().with_adapters(NoEdgeAndInputTypeChecking()).build()
 
         # now driver is built without any type checking

--- a/hamilton/plugins/h_dask.py
+++ b/hamilton/plugins/h_dask.py
@@ -141,7 +141,8 @@ class DaskGraphAdapter(base.HamiltonGraphAdapter):
         name = node.name + hash
         dask_key_name = str(node.name) + "_" + hash
         return delayed(node.callable, name=name)(
-            **kwargs, dask_key_name=dask_key_name  # this is what shows up in the dask console
+            **kwargs,
+            dask_key_name=dask_key_name,  # this is what shows up in the dask console
         )
 
     def build_result(self, **outputs: typing.Dict[str, typing.Any]) -> typing.Any:

--- a/hamilton/plugins/h_ddog.py
+++ b/hamilton/plugins/h_ddog.py
@@ -49,12 +49,8 @@ class DDOGTracer(
         self.service = service
         self.include_causal_links = include_causal_links
         self.run_span_cache = {}  # Cache of run_id -> span tuples
-        self.task_span_cache = (
-            {}
-        )  # cache of run_iod -> task_id -> span. Note that we will prune this after task execution
-        self.node_span_cache = (
-            {}
-        )  # Cache of run_id -> [task_id, node_id] -> span. We use this to open/close general traces
+        self.task_span_cache = {}  # cache of run_iod -> task_id -> span. Note that we will prune this after task execution
+        self.node_span_cache = {}  # Cache of run_id -> [task_id, node_id] -> span. We use this to open/close general traces
 
     @staticmethod
     def _serialize_span_dict(span_dict: Dict[str, Span]):

--- a/hamilton/plugins/h_experiments/server.py
+++ b/hamilton/plugins/h_experiments/server.py
@@ -231,7 +231,7 @@ def dataframe_to_table(df: pd.DataFrame, **kwargs) -> AnyComponent:
     Table = create_table_model(**{str(k): v for k, v in df.iloc[0].to_dict().items()})
 
     page: int = 1 if kwargs.get("page") is None else kwargs.get("page", 1)
-    page_size = df.shape[0] if df.shape[0] < 20 else 20
+    page_size = min(20, df.shape[0])
     page_df = df.iloc[(page - 1) * page_size : page * page_size]
 
     # create a Pydantic objects for each row

--- a/hamilton/plugins/h_experiments/server.py
+++ b/hamilton/plugins/h_experiments/server.py
@@ -8,9 +8,8 @@ import pandas as pd
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
-from fastui import AnyComponent, FastUI
+from fastui import AnyComponent, FastUI, prebuilt_html
 from fastui import components as c
-from fastui import prebuilt_html
 from fastui.components.display import DisplayLookup, DisplayMode
 from fastui.events import GoToEvent
 from fastui.forms import SelectSearchResponse

--- a/hamilton/plugins/h_pandera.py
+++ b/hamilton/plugins/h_pandera.py
@@ -36,15 +36,17 @@ class check_output(BaseDataValidationDecorator):
             from hamilton.plugins import h_pandera
             from pandera.typing.pandas import DataFrame
 
+
             class MySchema(pa.DataFrameModel):
                 a: int
                 b: float
                 c: str = pa.Field(nullable=True)  # For example, allow None values
-                d: float    # US dollars
+                d: float  # US dollars
+
 
             @h_pandera.check_output()
             def foo() -> DataFrame[MySchema]:
-                return pd.DataFrame() # will fail
+                return pd.DataFrame()  # will fail
 
         .. code-block:: python
             :name: "@check_output with passed in type"
@@ -58,9 +60,10 @@ class check_output(BaseDataValidationDecorator):
                 "d": pa.Column(pa.Float),
             })
 
+
             @function_modifiers.check_output(schema=schema)
             def foo() -> pd.DataFrame:
-                return pd.DataFrame() # will fail
+                return pd.DataFrame()  # will fail
 
         These two are functionally equivalent. Note that we do not (yet) support modification of the output.
         """

--- a/hamilton/plugins/h_polars.py
+++ b/hamilton/plugins/h_polars.py
@@ -17,9 +17,10 @@ class PolarsDataFrameResult(base.ResultMixin):
 
         from hamilton import base, driver
         from hamilton.plugins import polars_extensions
+
         polars_builder = polars_extensions.PolarsDataFrameResult()
         adapter = base.SimplePythonGraphAdapter(polars_builder)
-        dr =  driver.Driver(config, *modules, adapter=adapter)
+        dr = driver.Driver(config, *modules, adapter=adapter)
         df = dr.execute([...], inputs=...)  # returns polars dataframe
 
     Note: this is just a first attempt at something for Polars. Think it should handle more? Come chat/open a PR!

--- a/hamilton/plugins/h_polars_lazyframe.py
+++ b/hamilton/plugins/h_polars_lazyframe.py
@@ -17,9 +17,10 @@ class PolarsLazyFrameResult(base.ResultMixin):
 
         from hamilton import base, driver
         from hamilton.plugins import polars_extensions
+
         polars_builder = polars_extensions.PolarsLazyFrameResult()
         adapter = base.SimplePythonGraphAdapter(polars_builder)
-        dr =  driver.Driver(config, *modules, adapter=adapter)
+        dr = driver.Driver(config, *modules, adapter=adapter)
         df = dr.execute([...], inputs=...)  # returns polars dataframe
 
     Note: this is just a first attempt at something for Polars. Think it should handle more? Come chat/open a PR!

--- a/hamilton/plugins/h_schema.py
+++ b/hamilton/plugins/h_schema.py
@@ -13,7 +13,7 @@ from hamilton.experimental import h_databackends
 from hamilton.graph_types import HamiltonGraph, HamiltonNode
 from hamilton.lifecycle import GraphExecutionHook, NodeExecutionHook
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger(__name__)
 
 
 class Diff(enum.Enum):

--- a/hamilton/plugins/h_spark.py
+++ b/hamilton/plugins/h_spark.py
@@ -313,9 +313,7 @@ def _format_pandas_udf(func_name: str, ordered_params: List[str]) -> str:
     func_string = """
 def {name}({params}) -> {return_type}:
     return partial_fn({param_call})
-""".format(
-        **formatting_params
-    )
+""".format(**formatting_params)
     return func_string
 
 
@@ -328,9 +326,7 @@ def _format_udf(func_name: str, ordered_params: List[str]) -> str:
     func_string = """
 def {name}({params}):
     return partial_fn({param_call})
-""".format(
-        **formatting_params
-    )
+""".format(**formatting_params)
     return func_string
 
 

--- a/hamilton/plugins/h_vaex.py
+++ b/hamilton/plugins/h_vaex.py
@@ -25,9 +25,10 @@ class VaexDataFrameResult(base.ResultMixin):
 
         from hamilton import base, driver
         from hamilton.plugins import h_vaex
+
         vaex_builder = h_vaex.VaexDataFrameResult()
         adapter = base.SimplePythonGraphAdapter(vaex_builder)
-        dr =  driver.Driver(config, *modules, adapter=adapter)
+        dr = driver.Driver(config, *modules, adapter=adapter)
         df = dr.execute([...], inputs=...)  # returns vaex dataframe
 
     Note: this is just a first attempt at something for Vaex.
@@ -79,7 +80,6 @@ class VaexDataFrameResult(base.ResultMixin):
         df = None
 
         if arrays:
-
             # Check if all arrays have correct and identical shapes.
             first_expression_shape = next(arrays.values().__iter__()).shape
             if len(first_expression_shape) > 1:
@@ -99,7 +99,6 @@ class VaexDataFrameResult(base.ResultMixin):
             df = vaex.from_arrays(**arrays)
 
         elif scalars:
-
             # There are not arrays in outputs,
             # so we construct Vaex DataFrame with one row consisting of scalars.
             df = vaex.from_arrays(**{name: np.array([value]) for name, value in scalars.items()})

--- a/hamilton/plugins/kedro_extensions.py
+++ b/hamilton/plugins/kedro_extensions.py
@@ -25,7 +25,7 @@ class KedroSaver(DataSaver):
                 id="my_dataset__kedro",
                 dependencies=["my_dataset"],
                 dataset_name="my_dataset",
-                catalog=catalog
+                catalog=catalog,
             )
         )
     """

--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -1546,7 +1546,6 @@ class PandasExcelWriter(DataSaver):
         return writer_kwargs, to_excel_kwargs
 
     def save_data(self, data: DATAFRAME_TYPE) -> Dict[str, Any]:
-
         writer_kwargs, to_excel_kwargs = self._get_saving_kwargs()
 
         with pd.ExcelWriter(self.path, **writer_kwargs) as writer:

--- a/plugin_tests/h_ray/test_h_ray_workflow.py
+++ b/plugin_tests/h_ray/test_h_ray_workflow.py
@@ -1,11 +1,11 @@
 import pandas as pd
 import pytest
 import ray
-from plugin_tests.h_ray.resources import example_module, smoke_screen_module
 from ray import workflow
 
 from hamilton import base, driver
 from hamilton.plugins import h_ray
+from plugin_tests.h_ray.resources import example_module, smoke_screen_module
 
 
 @pytest.fixture(scope="module")

--- a/plugin_tests/h_ray/test_parse_ray_remote_options_from_tags.py
+++ b/plugin_tests/h_ray/test_parse_ray_remote_options_from_tags.py
@@ -2,7 +2,6 @@ from hamilton.plugins import h_ray
 
 
 def test_parse_ray_remote_options_from_tags():
-
     tags = {
         f"{h_ray.RAY_REMOTE_TAG_NAMESPACE}.resources": '{"GPU": 1}',
         "another_tag": "another_value",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,10 @@ line-length = 100
 target-version = "py38"  # Must include only the earliest supported version
 
 [tool.ruff.format]
-docstring-code-format = true
+docstring-code-format = false
+exclude = [
+    "docs/*",
+]
 
 [tool.ruff.lint]
 extend-select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,29 +183,29 @@ exclude = [
 extend-select = [
 #    "B",   # flake8-bugbear rules
 #    "C4",  # Helps you write better list/set/dict comprehensions.
-#    "E",   # pycodestyle errors
-#    "F",   # pyflakes
+    "E",   # pycodestyle errors
+    "F",   # pyflakes
 #    "FA",  # Verifies files use from __future__ import annotations if a type is used in the module that can be rewritten using PEP 563.
-#    "FURB",# Refurbishing and modernizing Python codebases
+    "FURB",# Refurbishing and modernizing Python codebases
 #    "G",   # flake8-logging-format rules
     "I",   # isort
-#    "ISC", # Encourage correct string literal concatenation.
-#    "LOG", # Checks for issues using the standard library logging module.
+    "ISC", # Encourage correct string literal concatenation.
+    "LOG", # Checks for issues using the standard library logging module.
 #    "N",   # Check PEP-8 naming conventions
 #    "NPY", # Linting rules for numpy
 #    "PERF",# Linting rules for performance
 #    "PIE", # flake8-pie rules
 #    "PT",  # flake8-pytest-style rules
 #    "PYI", # Linting rules for type annotations.
-#    "Q",   # Linting rules for quites
+    "Q",   # Linting rules for quites
 #    "RUF", # Unused noqa directive
 #    "SIM", # Linting rules for simplicity
 #    "T20", # Check for Print statements in python files.
-#    "TCH", # Move type-only imports to a type-checking block.
-#    "TID", # Helps you write tidier imports.
+    "TCH", # Move type-only imports to a type-checking block.
+    "TID", # Helps you write tidier imports.
 #    "TRY", # Prevent exception handling anti-patterns
 #    "UP",  # pyupgrade
-#    "W",   # pycodestyle warnings
+    "W",   # pycodestyle warnings
 ]
 extend-ignore = [
     "ISC001", # Checks for implicitly concatenated strings on a single line.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,10 @@ dask-dataframe = ["dask[dataframe]"]
 dask-diagnostics = ["dask[diagnostics]"]
 dask-distributed = ["dask[distributed]"]
 datadog = ["ddtrace"]
-dev = ["pre-commit"]
+dev = [
+  "pre-commit",
+  "ruff",
+]
 diskcache = ["diskcache"]
 docs = [
   "sf-hamilton[dev]",
@@ -159,12 +162,6 @@ issues = "https://github.com/dagworks-inc/hamilton/issues"
 source = "https://github.com/dagworks-inc/hamilton"
 slack = "https://join.slack.com/t/hamilton-opensource/shared_invite/zt-2niepkra8-DGKGf_tTYhXuJWBTXtIs4g"
 
-[tool.black]
-line-length = 100
-exclude = "docs/*.py"
-verbose = true
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312', 'py313']  # Must include all supported versions
-
 [tool.isort]
 profile = "black"
 known_local_folder = "tests"
@@ -183,32 +180,36 @@ line_length = 100
 line-length = 100
 target-version = "py38"  # Must include only the earliest supported version
 
+[tool.ruff.format]
+docstring-code-format = true
+
 [tool.ruff.lint]
 extend-select = [
-    "B",   # flake8-bugbear rules
-    "C4",  # Helps you write better list/set/dict comprehensions.
-    "E",   # pycodestyle errors
-    "F",   # pyflakes
-    "FA",  # Verifies files use from __future__ import annotations if a type is used in the module that can be rewritten using PEP 563.
-    "FURB",# Refurbishing and modernizing Python codebases
-    "G",   # flake8-logging-format rules
-    "I",   # isort
-    "ISC", # Encourage correct string literal concatenation.
-    "LOG", # Checks for issues using the standard library logging module.
-    "N",   # Check PEP-8 naming conventions
-    "NPY", # Linting rules for numpy
-    "PERF",# Linting rules for performance
-    "PIE", # flake8-pie rules
-    "PT",  # flake8-pytest-style rules
-    "PYI", # Linting rules for type annotations.
-    "Q",   # Linting rules for quites
-    "RUF", # Unused noqa directive
-    "T20", # Check for Print statements in python files.
-    "TCH", # Move type-only imports to a type-checking block.
-    "TID", # Helps you write tidier imports.
-    "TRY", # Prevent exception handling anti-patterns
-    "UP",  # pyupgrade
-    "W",   # pycodestyle warnings
+#    "B",   # flake8-bugbear rules
+#    "C4",  # Helps you write better list/set/dict comprehensions.
+#    "E",   # pycodestyle errors
+#    "F",   # pyflakes
+#    "FA",  # Verifies files use from __future__ import annotations if a type is used in the module that can be rewritten using PEP 563.
+#    "FURB",# Refurbishing and modernizing Python codebases
+#    "G",   # flake8-logging-format rules
+#    "I",   # isort
+#    "ISC", # Encourage correct string literal concatenation.
+#    "LOG", # Checks for issues using the standard library logging module.
+#    "N",   # Check PEP-8 naming conventions
+#    "NPY", # Linting rules for numpy
+#    "PERF",# Linting rules for performance
+#    "PIE", # flake8-pie rules
+#    "PT",  # flake8-pytest-style rules
+#    "PYI", # Linting rules for type annotations.
+#    "Q",   # Linting rules for quites
+#    "RUF", # Unused noqa directive
+#    "SIM", # Linting rules for simplicity
+#    "T20", # Check for Print statements in python files.
+#    "TCH", # Move type-only imports to a type-checking block.
+#    "TID", # Helps you write tidier imports.
+#    "TRY", # Prevent exception handling anti-patterns
+#    "UP",  # pyupgrade
+#    "W",   # pycodestyle warnings
 ]
 extend-ignore = [
     "ISC001", # Checks for implicitly concatenated strings on a single line.
@@ -217,24 +218,20 @@ extend-ignore = [
     "E203", # whitespace before ':'
     "E402", # module level import not at top of file
     "E501", # line too long
+    "E721", # Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
     "W605", # invalid escape sequence
 ]
 exclude = [
     "docs/*",
+    "**/business_logic.py",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-local-folder = ["tests"]
-known-first-party = ["hamilton"]
-section-order = ["future", "standard-library", "third-party", "sdk", "hamilton", "first-party", "local-folder"]
-
-[tool.ruff.lint.isort.sections]
-hamilton = ["hamilton"]
-sdk = ["hamilton_sdk"]
+known-first-party = ["hamilton*"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
-    # at least this three should be fine in tests:
     "S101", # asserts allowed in tests...
     "ARG", # Unused function args -> fixtures nevertheless are functionally relevant...
     "FBT", # Don't care about booleans as positional arguments in tests, e.g. via @pytest.mark.parametrize()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,13 +162,6 @@ issues = "https://github.com/dagworks-inc/hamilton/issues"
 source = "https://github.com/dagworks-inc/hamilton"
 slack = "https://join.slack.com/t/hamilton-opensource/shared_invite/zt-2niepkra8-DGKGf_tTYhXuJWBTXtIs4g"
 
-[tool.isort]
-profile = "black"
-known_local_folder = "tests"
-known_first_party = "hamilton"
-skip = "docs"
-line_length = 100
-
 #[tool.mypy]
 #exclude = []
 
@@ -195,7 +188,7 @@ extend-select = [
 #    "FA",  # Verifies files use from __future__ import annotations if a type is used in the module that can be rewritten using PEP 563.
 #    "FURB",# Refurbishing and modernizing Python codebases
 #    "G",   # flake8-logging-format rules
-#    "I",   # isort
+    "I",   # isort
 #    "ISC", # Encourage correct string literal concatenation.
 #    "LOG", # Checks for issues using the standard library logging module.
 #    "N",   # Check PEP-8 naming conventions

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """The setup script."""
+
 import warnings
 
 from setuptools import setup

--- a/tests/function_modifiers/test_delayed.py
+++ b/tests/function_modifiers/test_delayed.py
@@ -95,7 +95,8 @@ def test_dynamic_fails_without_power_mode_fails():
 def test_config_derivation():
     decorator = resolve(
         when=ResolveAt.CONFIG_AVAILABLE,
-        decorate_with=lambda cols_to_extract, some_cols_you_might_want_to_extract=[]: extract_columns(
+        decorate_with=lambda cols_to_extract,
+        some_cols_you_might_want_to_extract=[]: extract_columns(
             *cols_to_extract + some_cols_you_might_want_to_extract
         ),
     )
@@ -108,9 +109,10 @@ def test_config_derivation():
 def test_delayed_with_optional():
     decorator = resolve(
         when=ResolveAt.CONFIG_AVAILABLE,
-        decorate_with=lambda cols_to_extract, some_cols_you_might_want_to_extract=[
-            "c"
-        ]: extract_columns(*cols_to_extract + some_cols_you_might_want_to_extract),
+        decorate_with=lambda cols_to_extract,
+        some_cols_you_might_want_to_extract=["c"]: extract_columns(
+            *cols_to_extract + some_cols_you_might_want_to_extract
+        ),
     )
     resolved = decorator.resolve(
         {"cols_to_extract": ["a", "b"], **CONFIG_WITH_POWER_MODE_ENABLED},
@@ -131,9 +133,10 @@ def test_delayed_with_optional():
 def test_delayed_without_power_mode_fails():
     decorator = resolve(
         when=ResolveAt.CONFIG_AVAILABLE,
-        decorate_with=lambda cols_to_extract, some_cols_you_might_want_to_extract=[
-            "c"
-        ]: extract_columns(*cols_to_extract + some_cols_you_might_want_to_extract),
+        decorate_with=lambda cols_to_extract,
+        some_cols_you_might_want_to_extract=["c"]: extract_columns(
+            *cols_to_extract + some_cols_you_might_want_to_extract
+        ),
     )
     with pytest.raises(base.InvalidDecoratorException):
         decorator.resolve(

--- a/tests/lifecycle/test_lifecycle_adapters_end_to_end.py
+++ b/tests/lifecycle/test_lifecycle_adapters_end_to_end.py
@@ -1,10 +1,9 @@
 from types import ModuleType
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import pytest
 
 from hamilton import ad_hoc_utils, driver, node
-from hamilton.graph import FunctionGraph
 from hamilton.io.materialization import to
 from hamilton.lifecycle.base import (
     BaseDoNodeExecute,
@@ -33,6 +32,9 @@ from .lifecycle_adapters_for_testing import (
     TrackingValidateGraphValidator,
     TrackingValidateNodeValidator,
 )
+
+if TYPE_CHECKING:
+    from hamilton.graph import FunctionGraph
 
 
 def _sample_driver(*lifecycle_adapters):

--- a/tests/lifecycle/test_lifecycle_adapters_end_to_end_task_based.py
+++ b/tests/lifecycle/test_lifecycle_adapters_end_to_end_task_based.py
@@ -1,12 +1,11 @@
 from collections import Counter
 from types import ModuleType
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import pytest
 
 from hamilton import ad_hoc_utils, driver, node
 from hamilton.execution.executors import SynchronousLocalTaskExecutor
-from hamilton.graph import FunctionGraph
 from hamilton.htypes import Collect, Parallelizable
 from hamilton.lifecycle.base import (
     BaseDoNodeExecute,
@@ -29,6 +28,9 @@ from .lifecycle_adapters_for_testing import (
     TrackingPostTaskExecuteHook,
     TrackingPreNodeExecuteHook,
 )
+
+if TYPE_CHECKING:
+    from hamilton.graph import FunctionGraph
 
 
 def _sample_driver(*lifecycle_adapters):

--- a/tests/plugins/test_mlflow_extension.py
+++ b/tests/plugins/test_mlflow_extension.py
@@ -10,6 +10,7 @@ pytestmark = pytest.mark.skipif(
 
 if not PY38_OR_BELOW:
     import mlflow
+
     from hamilton.plugins.mlflow_extensions import MLFlowModelLoader, MLFlowModelSaver
 
 import numpy as np

--- a/tests/plugins/test_pandas_extensions.py
+++ b/tests/plugins/test_pandas_extensions.py
@@ -280,7 +280,6 @@ def test_pandas_excel_reader(tmp_path: pathlib.Path) -> None:
 
 
 def test_pandas_table_reader(tmp_path: pathlib.Path) -> None:
-
     path_to_test = "tests/resources/data/test_load_from_data.csv"
     reader = PandasTableReader(filepath_or_buffer=path_to_test)
     df, metadata = reader.load_data(pd.DataFrame)

--- a/ui/backend/server/commands.py
+++ b/ui/backend/server/commands.py
@@ -9,9 +9,10 @@ from contextlib import contextmanager
 from enum import Enum
 from typing import Optional
 
-import hamilton_ui
 import requests
 from django.core.management import execute_from_command_line
+
+import hamilton_ui
 
 logger = logging.getLogger(__name__)
 

--- a/ui/backend/server/manage.py
+++ b/ui/backend/server/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/ui/backend/server/trackingserver_auth/migrations_sqlite/0001_initial.py
+++ b/ui/backend/server/trackingserver_auth/migrations_sqlite/0001_initial.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/ui/backend/server/trackingserver_projects/migrations_sqlite/0001_initial.py
+++ b/ui/backend/server/trackingserver_projects/migrations_sqlite/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/ui/backend/server/trackingserver_run_tracking/migrations_sqlite/0001_initial.py
+++ b/ui/backend/server/trackingserver_run_tracking/migrations_sqlite/0001_initial.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/ui/backend/server/trackingserver_template/migrations_sqlite/0001_initial.py
+++ b/ui/backend/server/trackingserver_template/migrations_sqlite/0001_initial.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/ui/sdk/requirements-test.txt
+++ b/ui/sdk/requirements-test.txt
@@ -1,5 +1,6 @@
 ibis-framework
 langchain_core
+numpy<2  # SPARK-48710
 polars
 pyarrow
 pydantic

--- a/ui/sdk/requirements-test.txt
+++ b/ui/sdk/requirements-test.txt
@@ -3,6 +3,7 @@ langchain_core
 numpy<2  # SPARK-48710
 polars
 pyarrow
+pyarrow_hotfix  # required for ibis tests
 pydantic
 pyspark
 pytest

--- a/ui/sdk/requirements-test.txt
+++ b/ui/sdk/requirements-test.txt
@@ -1,6 +1,7 @@
 ibis-framework
 langchain_core
 polars
+pyarrow
 pydantic
 pyspark
 pytest

--- a/ui/sdk/ruff.toml
+++ b/ui/sdk/ruff.toml
@@ -1,6 +1,6 @@
 line-length = 100
 
 
-[per-file-ignores]
+[lint.per-file-ignores]
 # skip line length for API client files.
 "src/dagworks/api/*" = ["E501"]

--- a/ui/sdk/src/hamilton_sdk/tracking/dataframe_stats.py
+++ b/ui/sdk/src/hamilton_sdk/tracking/dataframe_stats.py
@@ -13,7 +13,7 @@ def type_converter(obj: Any) -> Any:
         result = int(obj)
     elif isinstance(obj, np.floating):
         result = float(obj)
-    elif isinstance(obj, np.complex_):
+    elif isinstance(obj, np.complexfloating) or isinstance(obj, getattr(np, "complex_", ())):
         result = complex(obj)
     elif isinstance(obj, dict):
         result = {}

--- a/ui/sdk/tests/tracking/test_dataframe_stats.py
+++ b/ui/sdk/tests/tracking/test_dataframe_stats.py
@@ -3,7 +3,13 @@ import math
 import numpy as np
 import pandas as pd
 from hamilton_sdk.tracking import dataframe_stats
-from pytest import mark
+from pytest import mark, param
+
+
+skip_NAN_on_numpy_v2 = mark.skipif(
+    not hasattr(np, "NAN"),
+    reason="NAN is not available in numpy v2",
+)
 
 
 # Tests the type converter
@@ -21,7 +27,7 @@ from pytest import mark
         ({"a": 1, "b": 2, "c": {"d": np.int8(3), "e": 4}}, {"a": 1, "b": 2, "c": {"d": 3, "e": 4}}),
         (pd.NaT, None),
         (pd.NA, None),
-        (np.NAN, None),
+        param(getattr(np, "NAN", np.nan), None, marks=skip_NAN_on_numpy_v2),
         (np.nan, None),
         (math.nan, None),
         # (math.inf, None),


### PR DESCRIPTION
[Ruff](https://docs.astral.sh/ruff/) is faster, and some might say more modern, alternative to multiple other tools.
- This PR turns on a subset of Ruff that is equivalent to Black, isort, and no-plugin flake8, combined.
- This is a continuation of #1088.

## Changes
(See individual commit titles)

## How I tested this
Evaluated the pre-commit hooks until they passed.

## Notes
As discussed on Slack, some inspections, when enabled (or unexcluded), detect a lot of violations, so enabling rules and rule families will need to be done carefully. This will require an additional effort, potentially outside the scope of this PR.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
