### PR TITLE
Fix: issue #1297: datasaver does not work with __future__.annotations

### DIFF
--- a/hamilton/function_modifiers/adapters.py
+++ b/hamilton/function_modifiers/adapters.py
@@ -878,7 +878,7 @@ class datasaver(NodeCreator):
                 f"Function: {fn.__qualname__} must have a return annotation."
             )
         origin = typing.get_origin(return_annotation)
-        if return_annotation is not dict and origin is not dict:
+        if return_annotation not in (dict, Dict, "dict", "dict_") and origin not in (dict, Dict, "dict", "dict_"):
             raise InvalidDecoratorException(f"Function: {fn.__qualname__} must return a dict.")
 
     def generate_nodes(self, fn: Callable, config) -> list[node.Node]:

--- a/tests/function_modifiers/test_adapters.py
+++ b/tests/function_modifiers/test_adapters.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import dataclasses
 from collections import Counter


### PR DESCRIPTION
Fixes issue #1297 by changing return_annotation retrieval `function_modifiers.adapters.datasaver.validate`.

## Changes
- modified `datasaver.validate` to check against `__future__.annotations` compatible type hints

## How I tested this
- added `from __future__ import annotations` to test_adapters
- ran `pytest tests/function_modifiers` &rarr; test failed
- made above changes
- ran `pytest tests/function_modifiers` &rarr; test succeeded

## Notes
<s>
`correct_ds_function` in `test_adapters.py` uses an alias for `dict`: `dict_ = dict`.
However, for the string comparison this is not resolved to `dict`; added `dict_` to the validation for now.

I do not understand why this is done in the tests and should, in theory, not impact "normal" use.
Feedback on this is welcome.
</s>

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
