### PR TITLE
Update extract fields

### DIFF
--- a/docs/concepts/function-modifiers.rst
+++ b/docs/concepts/function-modifiers.rst
@@ -201,7 +201,7 @@ A good example is splitting a dataset into training, validation, and test splits
     from typing import Tuple
     from hamilton.function_modifiers import unpack_fields
 
-    @unpack_fields("X_train" "X_validation", "X_test")
+    @unpack_fields("X_train", "X_validation", "X_test")
     def dataset_splits(X: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Randomly split data into train, validation, test"""
         X_train, X_validation, X_test = random_split(X)

--- a/docs/concepts/function-modifiers.rst
+++ b/docs/concepts/function-modifiers.rst
@@ -140,7 +140,7 @@ The ``@check_output`` function modifiers are applied on the **node output / func
 
 .. note::
 
-    In the future, validatation capabailities may be added to ``@schema``. For now, it's only added metadata.
+    In the future, validation capabilities may be added to ``@schema``. For now, it's only added metadata.
 
 @check_output*
 ~~~~~~~~~~~~~~
@@ -216,14 +216,14 @@ Now, ``X_train``, ``X_validation``, and ``X_test`` are available to other nodes 
 @extract_fields
 ~~~~~~~~~~~~~~~
 
-Additionally, we can extract fields from an output dictionary using ``@extract_fields``. In this case, you must specify the dictionary keys and their types. The function must return a dictionary that contains, at a minimum, those keys specified in the decorator.
+Additionally, we can extract fields from an output dictionary using ``@extract_fields``. The function must return a dictionary that contains, at a minimum, those keys specified in the decorator. In this case, you can specify a dictionary of fields and their types:
 
 .. code-block:: python
 
     from typing import Dict
     from hamilton.function_modifiers import extract_fields
 
-    @extract_fields(dict(  # don't forget the dictionary
+    @extract_fields(dict(  # fields specified as a dictionary
         X_train=np.ndarray,
         X_validation=np.ndarray,
         X_test=np.ndarray,
@@ -239,6 +239,68 @@ Additionally, we can extract fields from an output dictionary using ``@extract_f
 
 .. image:: ./_function-modifiers/extract_fields.png
     :height: 250px
+
+Or if you are using a generic dictionary, you can specify solely the field names.
+
+.. code-block:: python
+
+    from typing import Dict
+    from hamilton.function_modifiers import extract_fields
+
+    @extract_fields("X_train", "X_validation", "X_test")  # field names only
+    def dataset_splits(X: np.ndarray) -> Dict[str, np.ndarray]:  # generic dict
+        """Randomly split data into train, validation, test"""
+        X_train, X_validation, X_test = random_split(X)
+        return dict(
+            X_train=X_train,
+            X_validation=X_validation,
+            X_test=X_test,
+        )
+
+If you are using a `TypedDict`, you can specify the just field names.
+
+.. code-block:: python
+
+    from typing import TypedDict
+    from hamilton.function_modifiers import extract_fields
+
+    class DatasetSplits(TypedDict):
+        X_train: np.ndarray
+        X_validation: np.ndarray
+        X_test: np.ndarray
+
+    @extract_fields("X_train", "X_validation", "X_test")
+    def dataset_splits(X: np.ndarray) -> DatasetSplits:
+        """Randomly split data into train, validation, test"""
+        X_train, X_validation, X_test = random_split(X)
+        return dict(
+            X_train=X_train,
+            X_validation=X_validation,
+            X_test=X_test,
+        )
+
+
+Or you can leave the field names empty and extract all fields from the `TypedDict`.
+
+.. code-block:: python
+
+    from typing import TypedDict
+    from hamilton.function_modifiers import extract_fields
+
+    class DatasetSplits(TypedDict):
+        X_train: np.ndarray
+        X_validation: np.ndarray
+        X_test: np.ndarray
+
+    @extract_fields(DatasetSplits)  # field names only
+    def dataset_splits(X: np.ndarray) -> DatasetSplits:
+        """Randomly split data into train, validation, test"""
+        X_train, X_validation, X_test = random_split(X)
+        return dict(
+            X_train=X_train,
+            X_validation=X_validation,
+            X_test=X_test,
+        )
 
 
 Again, ``X_train``, ``X_validation``, and ``X_test`` are now available to other nodes, or you can query the ``dataset_splits`` node to retrieve all splits in a dictionary.

--- a/hamilton/function_modifiers/expanders.py
+++ b/hamilton/function_modifiers/expanders.py
@@ -836,30 +836,15 @@ class extract_fields(base.SingleNodeNodeTransformer):
         for field, field_type in self.fields.items():
             doc_string = base_doc  # default doc string of base function.
 
-            # if fn is async
-            if inspect.iscoroutinefunction(fn):
-
-                async def extractor_fn(field_to_extract: str = field, **kwargs) -> field_type:
-                    dt = kwargs[node_.name]
-                    if field_to_extract not in dt:
-                        raise base.InvalidDecoratorException(
-                            f"No such field: {field_to_extract} produced by {node_.name}. "
-                            f"It only produced {list(dt.keys())}"
-                        )
-                    return kwargs[node_.name][field_to_extract]
-
-            else:
-
-                def extractor_fn(
-                    field_to_extract: str = field, **kwargs
-                ) -> field_type:  # avoiding problems with closures
-                    dt = kwargs[node_.name]
-                    if field_to_extract not in dt:
-                        raise base.InvalidDecoratorException(
-                            f"No such field: {field_to_extract} produced by {node_.name}. "
-                            f"It only produced {list(dt.keys())}"
-                        )
-                    return kwargs[node_.name][field_to_extract]
+            # This extractor is constructed to avoid closure issues.
+            def extractor_fn(field_to_extract: str = field, **kwargs) -> field_type:  # type: ignore
+                dt = kwargs[node_.name]
+                if field_to_extract not in dt:
+                    raise base.InvalidDecoratorException(
+                        f"No such field: {field_to_extract} produced by {node_.name}. "
+                        f"It only produced {list(dt.keys())}"
+                    )
+                return kwargs[node_.name][field_to_extract]
 
             output_nodes.append(
                 node.Node(

--- a/hamilton/function_modifiers/expanders.py
+++ b/hamilton/function_modifiers/expanders.py
@@ -699,10 +699,11 @@ class extract_columns(base.SingleNodeNodeTransformer):
         return output_nodes
 
 
-def _process_extract_fields(
+def _determine_fields_to_extract(
     fields: Optional[Union[Dict[str, Any], List[str]]], output_type: Any
 ) -> Dict[str, Any]:
-    """Processes the fields and base output type to extract a dict of field types.
+    """Determines which fields to extract based on user requested fields and the output type of
+    the return type of the function.
 
     :param fields: Dict of fields to extract.
     :param output_type: The output type of the node function.
@@ -856,7 +857,7 @@ class extract_fields(base.SingleNodeNodeTransformer):
         :raises: InvalidDecoratorException If the function is not annotated with a dict or typing.Dict type as output.
         """
         self.output_type = typing.get_type_hints(fn).get("return")
-        self.resolved_fields = _process_extract_fields(self.fields, self.output_type)
+        self.resolved_fields = _determine_fields_to_extract(self.fields, self.output_type)
 
     def transform_node(
         self, node_: node.Node, config: Dict[str, Any], fn: Callable
@@ -922,8 +923,9 @@ class extract_fields(base.SingleNodeNodeTransformer):
         return output_nodes
 
 
-def _process_unpack_fields(fields: List[str], output_type: Any) -> List[Type]:
-    """Processes the fields and base output type to extract a list of field types.
+def _determine_fields_to_unpack(fields: List[str], output_type: Any) -> List[Type]:
+    """Determines which fields to unpack based on user requested fields and the output type of
+    the return type of the function.
 
     :param fields: List of fields to to unpack.
     :param output_type: The output type of the node function.
@@ -1006,7 +1008,7 @@ class unpack_fields(base.SingleNodeNodeTransformer):
     @override
     def validate(self, fn: Callable):
         output_type = typing.get_type_hints(fn).get("return")
-        field_types = _process_unpack_fields(self.fields, output_type)
+        field_types = _determine_fields_to_unpack(self.fields, output_type)
         self.field_types = field_types
         self.output_type = output_type
 

--- a/hamilton/function_modifiers/expanders.py
+++ b/hamilton/function_modifiers/expanders.py
@@ -851,7 +851,8 @@ class extract_fields(base.SingleNodeNodeTransformer):
         self.fill_with = fill_with
 
     def validate(self, fn: Callable):
-        """A function is invalid if it is not annotated with a dict or typing.Dict return type.
+        """A function is invalid if it is not annotated with a dict or typing.Dict return type or if the
+        fields to extract are not valid.
 
         :param fn: Function to validate.
         :raises: InvalidDecoratorException If the function is not annotated with a dict or typing.Dict type as output.
@@ -1007,6 +1008,11 @@ class unpack_fields(base.SingleNodeNodeTransformer):
 
     @override
     def validate(self, fn: Callable):
+        """Validates that the return type of the function is a tuple or typing.Tuple with the
+
+        :param fn: Function to validate
+        :raises: InvalidDecoratorException If the function does not output a tuple or typing.Tuple type.
+        """
         output_type = typing.get_type_hints(fn).get("return")
         field_types = _determine_fields_to_unpack(self.fields, output_type)
         self.field_types = field_types
@@ -1016,6 +1022,14 @@ class unpack_fields(base.SingleNodeNodeTransformer):
     def transform_node(
         self, node_: node.Node, config: Dict[str, Any], fn: Callable
     ) -> Collection[node.Node]:
+        """Unpacks the specified fields form the tuple output into separate nodes.
+
+        :param node_: Node to transform
+        :param config: Config to use
+        :param fn: Function to unpack fields from. Must output a tuple.
+        :return: A collection of nodes --
+                one for the original tuple generator, and another for each field to unpack.
+        """
         fn = node_.callable
         base_doc = node_.documentation
         base_tags = node_.tags.copy()

--- a/hamilton/function_modifiers/expanders.py
+++ b/hamilton/function_modifiers/expanders.py
@@ -700,7 +700,7 @@ class extract_columns(base.SingleNodeNodeTransformer):
 
 
 def _process_extract_fields(
-    fields: Optional[Dict[str, Any] | List[str]], output_type: Any
+    fields: Optional[Union[Dict[str, Any], List[str]]], output_type: Any
 ) -> Dict[str, Any]:
     """Processes the fields and base output type to extract a dict of field types.
 
@@ -826,7 +826,7 @@ class extract_fields(base.SingleNodeNodeTransformer):
 
     def __init__(
         self,
-        fields: Optional[Dict[str, Any] | List[str] | Any] = None,
+        fields: Optional[Union[Dict[str, Any], List[str], Any]] = None,
         *others,
         fill_with: Any = None,
     ):

--- a/tests/function_modifiers/test_expanders.py
+++ b/tests/function_modifiers/test_expanders.py
@@ -673,7 +673,7 @@ def test_extract_fields_transform_not_using_fill_with():
         nodes[1].callable(dummy_dict=dummy_dict())
 
 
-def test_unpack_fields_valid_explicit_tuple():
+def test_unpack_fields_transform_on_explicit_tuple():
     def dummy() -> Tuple[int, str, int]:
         """dummy doc"""
         return 1, "2", 3
@@ -704,7 +704,7 @@ def test_unpack_fields_valid_explicit_tuple():
     assert nodes[3].input_types == {dummy.__name__: (Tuple[int, str, int], DependencyType.REQUIRED)}
 
 
-def test_unpack_fields_valid_explicit_tuple_subset():
+def test_unpack_fields_transform_on_explicit_tuple_subset():
     def dummy() -> Tuple[int, str, int]:
         """dummy doc"""
         return 1, "2", 3
@@ -727,7 +727,7 @@ def test_unpack_fields_valid_explicit_tuple_subset():
     assert nodes[1].input_types == {dummy.__name__: (Tuple[int, str, int], DependencyType.REQUIRED)}
 
 
-def test_unpack_fields_valid_indeterminate_tuple():
+def test_unpack_fields_transform_on_indeterminate_tuple():
     def dummy() -> Tuple[int, ...]:
         """dummy doc"""
         return 1, 2, 3


### PR DESCRIPTION
Updated the existing function modifier `extract_fields` so that it can infer field types from the type annotation. 

> [!WARNING] 
>Important: This PR is based on the branch in #1303 and not `main`. Recommend merging that branch first. Sorry for the confusion!

## Changes

- Isolated the field extraction logic in a helper function called `_process_extract_fields` this function determines field types when necessary before calling the preexisting helper `_validate_extract_fields`
- The `extract_fields` class now calls `_process_extract_fields` directly (instead of `_validate_extract_fields`)
- Documentation on using `extract_fields` was updated to include unpacked field names, list of field names, and the previously undocumented `TypedDict`

## How I tested this

- Added test cases to validate the functionality of the `extract_fields` decorator with inferred field types
- Updated and consolidated existing annotation checks to handle explicit field types, inferred field types, and `TypedDicts`

## Notes

To use this feature you must specify a generic dictionary with valid type paramerters - therefore it will only work for homogenous dictionaries. For example, the following would extract the standard `X_train`, `X_test`, `y_train`, and `y_test` as `np.ndarray` by using unpacked field names:

```python
@extract_fields('X_train', 'X_test' 'y_train' 'y_test')  # unpacked field names
def train_test_split_func(...) -> Dict[str, np.ndarray]:
    ...
    return {"X_train": ..., "X_test": ..., "y_train": ..., "y_test": ...}
```

You can also pass a list of field names to the first argument:

```python
@extract_fields(['X_train', 'X_test' 'y_train' 'y_test'])   # list of field names
def train_test_split_func(...) -> Dict[str, np.ndarray]:
    ...
    return {"X_train": ..., "X_test": ..., "y_train": ..., "y_test": ...}
```

This also preserves backward compatibility with non-generic dictionaries:
```python
@extract_fields(dict(  # fields specified as a dictionary
    X_train=np.ndarray,
    X_validation=np.ndarray,
    X_test=np.ndarray,
))
def train_test_split_func(...) -> Dict:
    ...
    return {"X_train": ..., "X_test": ..., "y_train": ..., "y_test": ...}
```

## Checklist

- [X] PR has an informative and human-readable title (this will be pulled into the release notes)
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future TODOs are captured in comments
- [X] Project documentation has been updated if adding/changing functionality.
