### PR TITLE
Fixes code of conduct links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@
 > All contributions to this project will be released under the [Apache 2.0 License](LICENSE). .
 > By submitting a pull request or filing a bug, issue, or
 > feature request, you are agreeing to comply with this waiver of copyright interest.
-> You're also agreeing to abide by the ASF Code of Conduct.
+> You're also agreeing to abide by the ASF Code of Conduct (https://www.apache.org/foundation/policies/conduct.html)
 
 
 There are two primary ways to help:

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Apache Hamilton is released under the Apache 2.0 License. See [LICENSE](https://
 ## 👨‍💻 Contributing
 We're very supportive of changes by new contributors, big or small! Make sure to discuss potential changes by creating an issue or commenting on an existing one before opening a pull request. Good first contributions include creating an example or an integration with your favorite Python library!
 
- To contribute, checkout our [contributing guidelines](https://github.com/apache/hamilton/blob/main/CONTRIBUTING.md), our [developer setup guide](https://github.com/apache/hamilton/blob/main/developer_setup.md), and our [Code of Conduct](https://github.com/apache/hamilton/blob/main/CODE_OF_CONDUCT.md).
+ To contribute, checkout our [contributing guidelines](https://github.com/apache/hamilton/blob/main/CONTRIBUTING.md), our [developer setup guide](https://github.com/apache/hamilton/blob/main/developer_setup.md), and our [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
 
 
 ## 😎 Used by

--- a/docs/get-started/contributing.rst
+++ b/docs/get-started/contributing.rst
@@ -4,5 +4,5 @@ Contributing
 
 We are open contributions big and small. See our `contributing guidelines <https://github.com/apache/hamilton/blob/main/CONTRIBUTING.md>`__.
 
-We also operate under a `Code of Conduct <https://github.com/apache/hamilton/blob/main/CODE\_OF\_CONDUCT.md>`__, and
+We also operate under a `Code of Conduct <https://www.apache.org/foundation/policies/conduct.html>`__, and
 expect contributors to do the same.


### PR DESCRIPTION
This fixes #1385 .

This makes the code of conduct links all
point to ASF site.

## Changes
- docs files 

## How I tested this
- looked at them

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
