### PR TITLE
FIX: remove deprecated pandas CSV reader args (keep_date_col, verbose, delim_whitespace)

### DIFF
--- a/hamilton/plugins/pandas_extensions.py
+++ b/hamilton/plugins/pandas_extensions.py
@@ -205,14 +205,10 @@ class PandasCSVReader(DataLoader):
             kwargs["keep_default_na"] = self.keep_default_na
         if self.na_filter is not None:
             kwargs["na_filter"] = self.na_filter
-        if self.verbose is not None:
-            kwargs["verbose"] = self.verbose
         if self.skip_blank_lines is not None:
             kwargs["skip_blank_lines"] = self.skip_blank_lines
         if self.parse_dates is not None:
             kwargs["parse_dates"] = self.parse_dates
-        if self.keep_date_col is not None:
-            kwargs["keep_date_col"] = self.keep_date_col
         if self.date_format is not None:
             kwargs["date_format"] = self.date_format
         if self.dayfirst is not None:
@@ -247,8 +243,6 @@ class PandasCSVReader(DataLoader):
             kwargs["dialect"] = self.dialect
         if self.on_bad_lines is not None:
             kwargs["on_bad_lines"] = self.on_bad_lines
-        if self.delim_whitespace is not None:
-            kwargs["delim_whitespace"] = self.delim_whitespace
         if self.low_memory is not None:
             kwargs["low_memory"] = self.low_memory
         if self.memory_map is not None:


### PR DESCRIPTION
**fix: remove deprecated pandas CSV reader args (`keep_date_col`, `verbose`, `delim_whitespace`)**
fixes #1417 

These pandas arguments are deprecated and generate warnings during the test suite.  
This PR removes them from Hamilton’s `PandasCSVReader` to maintain future compatibility and keep test output clean.

## Changes

- Removed usage of deprecated pandas CSV parameters:
  - `keep_date_col`
  - `verbose`
  - `delim_whitespace`
- Updated `_get_loading_kwargs()` to avoid passing these keywords.
- Ensures compatibility with newer pandas versions (≥ 2.x).
- Eliminates deprecation warnings observed.

## How I tested this

- Ran the test suite with pytest
- Confirmed that CSV-related tests pass without warnings

## Notes

## Checklist

- [x] PR has an informative, human-readable title
- [x] Changes limited to a single goal
- [x] Code passes pre-commit and removes old warnings
- [x] No functional behaviour change; only param cleanup
- [x] Any updated helper logic covered by existing tests
- [x] No leftover TODOs or placeholder code
- [x] Documentation not required (internal cleanup)
