### PR TITLE
fix: Update supported python versions in front page badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ under the License.
    <a href='https://hamilton.apache.org/?badge=latest'>
       <img src='https://readthedocs.org/projects/hamilton/badge/?version=latest' alt='Documentation Status' />
    </a><a href="https://www.python.org/downloads/" target="_blank">
-      <img src="https://img.shields.io/badge/python-3.8|%203.9|%203.10|%203.11|%203.12-blue.svg" alt="Python supported"/>
+      <img src="https://img.shields.io/badge/python-3.10%20|%203.11%20|%203.12%20|%203.13%20|%203.14-blue.svg" alt="Python supported"/>
    </a>
    <a href="https://pypi.org/project/sf-hamilton/" target="_blank">
       <img src="https://badge.fury.io/py/sf-hamilton.svg" alt="PyPi Version"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ ui = ["sf-hamilton-ui"]
 
 # vaex -- on >=py3.11 only core part available https://github.com/vaexio/vaex/pull/2331#issuecomment-2437198176
 vaex = [
-  "vaex; python_version <= '3.10'"
+  "vaex; python_version == '3.10'"
   ]
 visualization = ["graphviz", "networkx"]
 


### PR DESCRIPTION
## Changes
- Remove python 3.8, 3.9 and add 3.13, 3.14 instead
- Add spaces on both sides of the version numbers
- Update python version constraint for `vaex` to reflect the project's supported python versions

## How I tested this
<img src="https://img.shields.io/badge/python-3.10%20|%203.11%20|%203.12%20|%203.13%20|%203.14-blue.svg" alt="Python supported"/>

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
