### PR TITLE
Add missing dependency group for async SQLAlchemy tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ test = [
   "pytest-cov",
   "PyYAML",
   "scikit-learn",
-  "sqlalchemy",
+  "sqlalchemy[asyncio]",
   "typer",
   "xgboost; python_version < '3.14'",
   "xlsx2csv", # for excel data loader

--- a/tests/plugins/test_matplotlib_extensions.py
+++ b/tests/plugins/test_matplotlib_extensions.py
@@ -24,6 +24,8 @@ import pytest
 from hamilton.io.utils import FILE_METADATA
 from hamilton.plugins.matplotlib_extensions import MatplotlibWriter
 
+matplotlib.use("Agg")  # "Headless" backend for testing purposes
+
 
 def figure1():
     fig = plt.figure()


### PR DESCRIPTION
## Changes
This PR contains two fixes:

1. Fix for a CI issue:

```none
FAILED tests/plugins/test_polars_extensions.py::test_polars_database - ImportError: The SQLAlchemy asyncio
module requires that the Python 'greenlet' library is installed.  In order to ensure this dependency is
available, use the 'sqlalchemy[asyncio]' install target:  'pip install sqlalchemy[asyncio]'
```

2. Fix for Tkinter (matplotlib's default backend) not being detected when running tests locally in a uv venv.

## How I tested this
Ran the below locally and verified tests complete successfully.
```none
  uv sync --group test
  uv pip install "kaleido<0.4.0"
  uv run pytest tests/ --cov=hamilton --ignore tests/integrations
```

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
