### PR TITLE
Add the sphinx-llms-txt docs plugin for better LLM integration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,9 +73,17 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "myst_nb",
+    "sphinx_llms_txt",
     "sphinx_sitemap",
     "docs.data_adapters_extension",
 ]
+
+# sphinx-llms-txt configuration
+llms_txt_title = "Apache Hamilton"
+llms_txt_summary = (
+    "Apache Hamilton is a lightweight Python framework for creating "
+    "DAGs of data transformations using declarative function definitions."
+)
 
 nb_execution_mode = "off"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,8 @@ test = [
 ]
 docs = [
   {include-group = "dev"},
-  "alabaster>=0.7,<0.8,!=0.7.5", # read the docs pins
-  "commonmark==0.9.1", # read the docs pins
+  "alabaster",
+  "commonmark",
   "dask-expr>=1.1.14",
   "dask[distributed]",
   "ddtrace<3.0",
@@ -146,7 +146,7 @@ docs = [
   "lxml",
   "lz4",
   "mlflow",
-  "mock==1.0.1", # read the docs pins
+  "mock",
   "myst-nb",
   "narwhals",
   "numpy",
@@ -159,15 +159,15 @@ docs = [
   "pyspark",
   "openlineage-python",
   "PyYAML",
-  "ray",
-  "readthedocs-sphinx-ext<2.3", # read the docs pins
-  "recommonmark==0.5.0", # read the docs pins
+  "ray; python_version < '3.14'",
+  "readthedocs-sphinx-ext",
+  "recommonmark",
   "scikit-learn",
   "slack-sdk",
-  "sphinx", # unpinned because myst-parser doesn't break anymore
+  "sphinx",
   "sphinx-autobuild",
   "sphinx-llms-txt",
-  "sphinx-rtd-theme", # read the docs pins
+  "sphinx-rtd-theme",
   "sphinx-simplepdf",
   "sphinx-sitemap",
   "tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ docs = [
   "slack-sdk",
   "sphinx", # unpinned because myst-parser doesn't break anymore
   "sphinx-autobuild",
+  "sphinx-llms-txt",
   "sphinx-rtd-theme", # read the docs pins
   "sphinx-simplepdf",
   "sphinx-sitemap",


### PR DESCRIPTION
Add the sphinx-llms-txt extension to Hamilton's Sphinx documentation build. This auto-generates `llms.txt` (a compact index) and `llms-full.txt` (complete docs in one Markdown file) [llms-txt](https://llmstxt.org/) on every documentation deploy.

The plugin supports code file inclusion, custom summaries, and size limits. [Readthedocs](https://sphinx-llms-txt.readthedocs.io/en/latest/advanced-configuration.html) Since Hamilton already uses Sphinx + MyST on Read the Docs, integration requires only adding the extension to conf.py and configuring sections. This gives every LLM provider access to current, version-specific Hamilton documentation through a standardized URL.

## Changes
- Add `sphinx-llms-txt` to pyproject.toml and `docs/conf.py`
- Remove [outdated](https://blog.readthedocs.com/defaulting-latest-build-tools/) sphinx dependency pins

## How I tested this
Built the docs locally.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
