### PR TITLE
Fix resolve docs parameterization example

### DIFF
--- a/hamilton/function_modifiers/delayed.py
+++ b/hamilton/function_modifiers/delayed.py
@@ -78,7 +78,7 @@ class resolve(DynamicResolver):
 
     .. code-block:: python
 
-        @parameterize_values(
+        @parameterize_sources(
             series_sum_1={"s1": "series_1", "s2": "series_2"},
             series_sum_2={"s1": "series_3", "s2": "series_4"},
         )


### PR DESCRIPTION
## Summary
- Fix the `@resolve` reference docs example to use `@parameterize_sources` instead of `@parameterize_values`.
- The example maps function parameters to upstream source nodes, which matches `parameterize_sources` semantics and the later dynamic `@resolve` example.

Fixes #1384

## Test plan
- `python -m ruff check hamilton/function_modifiers/delayed.py`
- `git diff --check`