### PR TITLE
Fix: Add Python 3.14 constraint to ddtrace dependency (issue #1562)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dask-array = ["dask[array]"]
 dask-dataframe = ["dask[dataframe]"]
 dask-diagnostics = ["dask[diagnostics]"]
 dask-distributed = ["dask[distributed]"]
-datadog = ["ddtrace<3.0"]  # Temporary pin until h_ddog.py import is fixed for >3.0 version
+datadog = ["ddtrace<3.0; python_version < '3.14'"]  # Temporary pin until h_ddog.py import is fixed for >3.0 version
 diskcache = ["diskcache"]
 experiments = [
   "fastapi",


### PR DESCRIPTION
The upper limit of ddtrace in pyproject.toml causes build failures on Python 3.14 because ddtrace 2.x only provides wheels up to Python 3.13. This commit adds a Python version constraint to prevent Python 3.14+ from attempting to build a wheel for ddtrace<3.0, which would fail due to missing pkg_resources dependency.

Fixes #1562

<!-- SPDX-License-Identifier: Apache-2.0 -->

--- PR TEMPLATE INSTRUCTIONS (1) ---

Looking to submit a Apache Hamilton Dataflow to the sf-hamilton-contrib module? If so go the the `Preview` tab and select the appropriate sub-template:
* [sf-hamilton-contrib template](?expand=1&template=HAMILTON_CONTRIB_PR_TEMPLATE.md)

Else, if not, please remove this block of text.

--- PR TEMPLATE INSTRUCTIONS (2) ---

[Short description explaining the high-level reason for the pull request]

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.


Fix: Add Python 3.14 constraint to ddtrace dependency

Fixes #1562

The upper limit of ddtrace in pyproject.toml causes build failures on Python 3.14 because ddtrace 2.x only provides wheels up to Python 3.13. This adds a Python version constraint to prevent Python 3.14+ from attempting to build a wheel for ddtrace<3.0.