### PR TITLE
fix tqdm: Fix progress bar to 100% on successful execution

### DIFF
--- a/hamilton/plugins/h_tqdm.py
+++ b/hamilton/plugins/h_tqdm.py
@@ -111,12 +111,18 @@ class ProgressBar(
     def run_after_node_execution(self, **future_kwargs):
         self.progress_bar.update(1)
 
-    def run_after_graph_execution(self, **future_kwargs):
+    def run_after_graph_execution(self, *, success: bool = True, **future_kwargs):
         name_part = "Execution Complete!"
         if len(name_part) > self.node_name_target_width:
             padding = ""
         else:
             padding = " " * (self.node_name_target_width - len(name_part))
+        # Overrides are counted in `total` but never trigger run_after_node_execution,
+        # so on a successful run we top the bar up to 100% rather than leaving a gap.
+        if success and self.progress_bar.total is not None:
+            remaining = self.progress_bar.total - self.progress_bar.n
+            if remaining > 0:
+                self.progress_bar.update(remaining)
         self.progress_bar.set_description_str(f"{self.desc} -> {name_part + padding}")
         self.progress_bar.set_postfix({})
         self.progress_bar.close()

--- a/tests/plugins/test_h_tqdm.py
+++ b/tests/plugins/test_h_tqdm.py
@@ -32,12 +32,7 @@ def _build_driver(progress_bar: ProgressBar, module_name: str) -> driver.Driver:
     module = ad_hoc_utils.create_temporary_module(
         normalized, scaled, total, module_name=module_name
     )
-    return (
-        driver.Builder()
-        .with_adapters(progress_bar)
-        .with_modules(module)
-        .build()
-    )
+    return driver.Builder().with_adapters(progress_bar).with_modules(module).build()
 
 
 def test_progress_bar_reaches_total_with_overrides():
@@ -80,12 +75,7 @@ def test_progress_bar_does_not_force_completion_on_failure():
         step_one, step_two, step_three, module_name="tqdm_pipeline_failure"
     )
     progress_bar = ProgressBar()
-    dr = (
-        driver.Builder()
-        .with_adapters(progress_bar)
-        .with_modules(module)
-        .build()
-    )
+    dr = driver.Builder().with_adapters(progress_bar).with_modules(module).build()
 
     try:
         dr.execute(["step_three"], inputs={"raw_value": 1.0})

--- a/tests/plugins/test_h_tqdm.py
+++ b/tests/plugins/test_h_tqdm.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from hamilton import ad_hoc_utils, driver
+from hamilton.plugins.h_tqdm import ProgressBar
+
+
+def _build_driver(progress_bar: ProgressBar, module_name: str) -> driver.Driver:
+    def normalized(raw_value: float) -> float:
+        return raw_value / 100.0
+
+    def scaled(normalized: float) -> float:
+        return normalized * 10.0
+
+    def total(scaled: float) -> float:
+        return scaled + 5.0
+
+    module = ad_hoc_utils.create_temporary_module(
+        normalized, scaled, total, module_name=module_name
+    )
+    return (
+        driver.Builder()
+        .with_adapters(progress_bar)
+        .with_modules(module)
+        .build()
+    )
+
+
+def test_progress_bar_reaches_total_with_overrides():
+    """Regression test for #845: bar must hit 100% when overrides are passed."""
+    progress_bar = ProgressBar()
+    dr = _build_driver(progress_bar, "tqdm_pipeline_overrides")
+
+    dr.execute(
+        ["total"],
+        overrides={"scaled": 42.0},
+        inputs={"raw_value": 200.0},
+    )
+
+    assert progress_bar.progress_bar.n == progress_bar.progress_bar.total
+
+
+def test_progress_bar_reaches_total_without_overrides():
+    """Bar reaches 100% on a normal successful run."""
+    progress_bar = ProgressBar()
+    dr = _build_driver(progress_bar, "tqdm_pipeline_no_overrides")
+
+    dr.execute(["total"], inputs={"raw_value": 200.0})
+
+    assert progress_bar.progress_bar.n == progress_bar.progress_bar.total
+
+
+def test_progress_bar_does_not_force_completion_on_failure():
+    """Bar must not be forced to total when execution fails."""
+
+    def step_one(raw_value: float) -> float:
+        return raw_value
+
+    def step_two(step_one: float) -> float:
+        raise RuntimeError("boom")
+
+    def step_three(step_two: float) -> float:
+        return step_two
+
+    module = ad_hoc_utils.create_temporary_module(
+        step_one, step_two, step_three, module_name="tqdm_pipeline_failure"
+    )
+    progress_bar = ProgressBar()
+    dr = (
+        driver.Builder()
+        .with_adapters(progress_bar)
+        .with_modules(module)
+        .build()
+    )
+
+    try:
+        dr.execute(["step_three"], inputs={"raw_value": 1.0})
+    except Exception:
+        pass
+
+    assert progress_bar.progress_bar.n < progress_bar.progress_bar.total


### PR DESCRIPTION
## Changes
 - Fixes #845. The `h_tqdm.ProgressBar` adapter never reached 100% when `overrides` were passed to `.execute()` because override nodes are counted in the bar's `total` but do not trigger `run_after_node_execution`,
  leaving the bar short of `total` on a successful run.
 - On a successful graph execution we top up `progress_bar.n` to `progress_bar.total` inside `run_after_graph_execution`.. On failure we leave the partial count visible.

## How I tested this
 - UT
## Notes
 - N/A
## Checklist

- [X] PR has an informative and human-readable title (this will be pulled into the release notes)
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future TODOs are captured in comments
- [X] Project documentation has been updated if adding/changing functionality.
