### PR TITLE
[core] Fix false multiple decorator error when combining schema.output and tag

### DIFF
--- a/hamilton/function_modifiers/base.py
+++ b/hamilton/function_modifiers/base.py
@@ -119,12 +119,13 @@ class NodeTransformLifecycle(abc.ABC):
         """
         self.validate(fn)
         lifecycle_name = self.__class__.get_lifecycle_name()
-        if hasattr(fn, self.get_lifecycle_name()):
-            if not self.allows_multiple():
+        if hasattr(fn, lifecycle_name):
+            curr_value = getattr(fn, lifecycle_name)
+            same_class_present = any(d.__class__ is self.__class__ for d in curr_value)
+            if same_class_present and not self.allows_multiple():
                 raise ValueError(
                     f"Got multiple decorators for decorator @{self.__class__}. Only one allowed."
                 )
-            curr_value = getattr(fn, lifecycle_name)
             setattr(fn, lifecycle_name, curr_value + [self])
         else:
             setattr(fn, lifecycle_name, [self])

--- a/tests/function_modifiers/test_metadata.py
+++ b/tests/function_modifiers/test_metadata.py
@@ -231,6 +231,21 @@ def test_decorate_node_with_schema_output():
     )
 
 
+def test_schema_output_combined_with_tag_does_not_raise():
+    @function_modifiers.schema.output(("ticker", "str"), ("fee", "float"))
+    @function_modifiers.tag(table_type="reference")
+    def ref_table_1() -> pd.DataFrame:
+        return pd.DataFrame.from_records([{"ticker": "AAPL", "fee": 1.0}])
+
+    nodes = function_modifiers.base.resolve_nodes(ref_table_1, {})
+    node_map = {n.name: n for n in nodes}
+    node_ = node_map["ref_table_1"]
+    assert (
+        node_.tags[function_modifiers.schema.INTERNAL_SCHEMA_OUTPUT_KEY] == "ticker=str,fee=float"
+    )
+    assert node_.tags["table_type"] == "reference"
+
+
 def test_decorate_node_with_schema_output_invalid_type():
     # quick test to decorate node with schemas
     # this tests an internal implementation, so we will likely change


### PR DESCRIPTION
## Changes
  - SchemaOutput inherits from tag and shares its lifecycle name, so multiplicity check tripped on the existing tag instance.
  - Count only decorators of the same concrete class as self before raising, independent decorators sharing a lifecycle name now compose. 

## How I tested this
 - UT
## Notes

## Checklist

- [X] PR has an informative and human-readable title (this will be pulled into the release notes)
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future TODOs are captured in comments
- [X] Project documentation has been updated if adding/changing functionality.
