### PR TITLE
Use warnings.warn instead of logger.warning for deprecation notices

### DIFF
--- a/hamilton/driver.py
+++ b/hamilton/driver.py
@@ -27,6 +27,7 @@ import sys
 # required if we want to run this code stand alone.
 import typing
 import uuid
+import warnings
 from collections.abc import Callable, Collection, Sequence
 from datetime import datetime
 from types import ModuleType
@@ -544,9 +545,11 @@ class Driver:
             dataframe.
         """
         if display_graph:
-            logger.warning(
+            warnings.warn(
                 "display_graph=True is deprecated. It will be removed in the 2.0.0 release. "
-                "Please use visualize_execution()."
+                "Please use visualize_execution().",
+                DeprecationWarning,
+                stacklevel=2,
             )
         run_id = str(uuid.uuid4())
         run_successful = True
@@ -634,9 +637,11 @@ class Driver:
             function_graph, self.adapter, user_nodes, inputs, nodes
         )  # TODO -- validate within the function graph itself
         if display_graph:  # deprecated flow.
-            logger.warning(
+            warnings.warn(
                 "display_graph=True is deprecated. It will be removed in the 2.0.0 release. "
-                "Please use visualize_execution()."
+                "Please use visualize_execution().",
+                DeprecationWarning,
+                stacklevel=2,
             )
             self.visualize_execution(final_vars, "test-output/execute.gv", {"view": True})
             if self.has_cycles(
@@ -708,9 +713,11 @@ class Driver:
             function_graph, self.adapter, user_nodes, inputs, nodes
         )  # TODO -- validate within the function graph itself
         if display_graph:  # deprecated flow.
-            logger.warning(
+            warnings.warn(
                 "display_graph=True is deprecated. It will be removed in the 2.0.0 release. "
-                "Please use visualize_execution()."
+                "Please use visualize_execution().",
+                DeprecationWarning,
+                stacklevel=2,
             )
             self.visualize_execution(final_vars, "test-output/execute.gv", {"view": True})
             if self.has_cycles(

--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -29,6 +29,7 @@ import logging
 import os.path
 import pathlib
 import uuid
+import warnings
 from collections.abc import Callable, Collection
 from enum import Enum
 from types import ModuleType
@@ -989,11 +990,13 @@ class FunctionGraph:
         return dot
 
     def get_impacted_nodes(self, var_changes: list[str]) -> set[node.Node]:
-        """DEPRECATED - use `get_downstream_nodes` instead."""
-        logger.warning(
+        """Deprecated alias for `get_downstream_nodes`."""
+        warnings.warn(
             "FunctionGraph.get_impacted_nodes is deprecated. "
-            "Use `get_downstream_nodes` instead. This function will be removed"
-            "in a future release."
+            "Use `get_downstream_nodes` instead. This function will be removed "
+            "in the 2.0.0 release.",
+            DeprecationWarning,
+            stacklevel=2,
         )
         return self.get_downstream_nodes(var_changes)
 


### PR DESCRIPTION
## Changes
 - logger.warning does not fire in most CI/applications unless the app configures it.
 - warnings.warn is visible by default to pytest and python -W
 - Switch to warnings to so deprecation notices can reach users/CI tests.

## How I tested this
 - N/A
## Notes

## Checklist

- [X] PR has an informative and human-readable title (this will be pulled into the release notes)
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future TODOs are captured in comments
- [X] Project documentation has been updated if adding/changing functionality.
