### PR TITLE
docs: enable source links in API reference

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,6 +72,7 @@ html_css_files = [
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
     "myst_nb",
     "sphinx_llms_txt",
     "sphinx_sitemap",


### PR DESCRIPTION
## Summary

Enable `sphinx.ext.viewcode` in the Sphinx docs config so generated API reference pages include links back to the source code.

## Test Plan

- Attempted local Sphinx build
- Blocked locally by host packaging/env mismatch (`pip` on this machine does not support the repo's `--group docs` install flow)