### PR TITLE
Style async nodes in graph visualizations

### DIFF
--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -356,6 +356,10 @@ def create_graphviz_graph(
         else:
             return "function"
 
+    def _is_async_node(n: node.Node) -> bool:
+        """Returns whether a DAG node is backed by an async callable."""
+        return n.callable is not None and inspect.iscoroutinefunction(n.callable)
+
     def _get_node_style(node_type: str) -> dict[str, str]:
         """Get the style of a node type.
         Graphviz needs values to be strings.
@@ -408,6 +412,8 @@ def create_graphviz_graph(
             modifier_style = dict(style="filled,diagonals")
         elif modifier == "materializer":
             modifier_style = dict(shape="cylinder")
+        elif modifier == "async":
+            modifier_style = dict(fillcolor="#CDB4DB", style="rounded,filled,bold")
         elif modifier == "field":
             modifier_style = dict(fillcolor="#c8dae0", fontname="Courier")
         elif modifier == "cluster":
@@ -457,6 +463,7 @@ def create_graphviz_graph(
             "config",
             "input",
             "function",
+            "async",
             "cluster",
             "field",
             "output",
@@ -564,6 +571,11 @@ def create_graphviz_graph(
             modifier_style = _get_function_modifier_style("materializer")
             node_style.update(**modifier_style)
             seen_node_types.add("materializer")
+
+        if _is_async_node(n):
+            modifier_style = _get_function_modifier_style("async")
+            node_style.update(**modifier_style)
+            seen_node_types.add("async")
 
         # apply custom styles before node modifiers
         seen_node_type = None

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1273,6 +1273,37 @@ def test_create_graphviz_graph():
     assert dot_set == expected_set
 
 
+def test_create_graphviz_graph_styles_async_nodes():
+    async def async_node() -> int:
+        return 1
+
+    def sync_node(async_node: int) -> int:
+        return async_node + 1
+
+    module = ad_hoc_utils.create_temporary_module(async_node, sync_node)
+    fg = graph.FunctionGraph.from_modules(module, config={})
+
+    digraph = graph.create_graphviz_graph(
+        set(fg.get_nodes()),
+        "Dependency Graph\n",
+        graphviz_kwargs={},
+        node_modifiers={},
+        strictly_display_only_nodes_passed_in=False,
+        config={},
+    )
+    dot_source = str(digraph)
+
+    assert (
+        "\tasync_node [label=<<b>async_node</b><br /><br /><i>int</i>> "
+        'fillcolor="#CDB4DB" fontname=Helvetica margin=0.15 shape=rectangle '
+        'style="rounded,filled,bold"]'
+    ) in dot_source
+    assert (
+        '\t\tasync [fillcolor="#CDB4DB" fontname=Helvetica margin=0.15 '
+        'shape=rectangle style="rounded,filled,bold"]'
+    ) in dot_source
+
+
 def test_create_networkx_graph():
     """Tests that we create a networkx graph"""
     fg = graph.FunctionGraph.from_modules(tests.resources.dummy_functions, config={})


### PR DESCRIPTION
Adds a distinct graphviz style and legend entry for async-backed Hamilton nodes so DAG visualizations can signal when `AsyncDriver` is needed for execution.

## Changes

- Added async callable detection in graphviz visualization generation.
- Applied a distinct async node style and included it in the legend ordering.
- Added regression coverage asserting async nodes and their legend entry render with the async style.

## How I tested this

- `uv run --with pytest --with graphviz pytest tests/test_graph.py::test_create_graphviz_graph_styles_async_nodes`
- `uv run ruff format --check hamilton/graph.py tests/test_graph.py`
- `uv run ruff check hamilton/graph.py tests/test_graph.py`

## Notes

Fixes #1182.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.