### PR TITLE
Improve dynamic resolver power user mode error

### DIFF
--- a/hamilton/function_modifiers/delayed.py
+++ b/hamilton/function_modifiers/delayed.py
@@ -148,13 +148,13 @@ class resolve(DynamicResolver):
         return self._optional_config
 
     def resolve(self, config: dict[str, Any], fn: Callable) -> NodeTransformLifecycle:
-        if not config[settings.ENABLE_POWER_USER_MODE]:
+        if not config.get(settings.ENABLE_POWER_USER_MODE, False):
             raise InvalidDecoratorException(
-                "Dynamic functions are only allowed in power user mode!"
+                "Dynamic functions are only allowed in power user mode. "
                 "Why? This is occasionally needed to enable highly flexible "
                 "dataflows, but it can compromise readability if you're not "
-                "careful! To enable power user mode, pass in the configuration "
-                f"parameter {settings.ENABLE_POWER_USER_MODE}=True to your driver."
+                "careful! To enable power user mode, build your driver with "
+                f".with_config({{{settings.ENABLE_POWER_USER_MODE!r}: True}})."
             )
         missing_configs = []
         for item in self.required_config():

--- a/tests/function_modifiers/test_delayed.py
+++ b/tests/function_modifiers/test_delayed.py
@@ -167,11 +167,30 @@ def test_delayed_without_power_mode_fails():
             extract_columns(*cols_to_extract + some_cols_you_might_want_to_extract)
         ),
     )
-    with pytest.raises(base.InvalidDecoratorException):
+    with pytest.raises(base.InvalidDecoratorException) as exc_info:
         decorator.resolve(
             {"cols_to_extract": ["a", "b"], **CONFIG_WITH_POWER_MODE_DISABLED},
             fn=fn,
         )
+    error_message = str(exc_info.value)
+    assert "power user mode" in error_message
+    assert ".with_config({'hamilton.enable_power_user_mode': True})" in error_message
+
+
+def test_delayed_without_power_mode_config_fails_with_helpful_error():
+    def fn() -> pd.DataFrame:
+        return pd.DataFrame()
+
+    decorator = resolve(
+        when=ResolveAt.CONFIG_AVAILABLE,
+        decorate_with=lambda cols_to_extract: extract_columns(*cols_to_extract),
+    )
+
+    with pytest.raises(base.InvalidDecoratorException) as exc_info:
+        decorator.resolve({"cols_to_extract": ["a", "b"]}, fn=fn)
+    error_message = str(exc_info.value)
+    assert "power user mode" in error_message
+    assert ".with_config({'hamilton.enable_power_user_mode': True})" in error_message
 
 
 def test_dynamic_resolve_with_extract_fields():


### PR DESCRIPTION
Improves the error raised when dynamic resolver decorators are used without enabling power user mode, including the case where the config key is missing entirely.

## Changes

- Replaced direct indexing of `hamilton.enable_power_user_mode` with a defaulted config lookup.
- Updated the error text to point users at `.with_config({'hamilton.enable_power_user_mode': True})`.
- Added regression coverage for both explicit `False` and missing power-user-mode config.

## How I tested this

- `uv run --with pytest pytest tests/function_modifiers/test_delayed.py::test_delayed_without_power_mode_fails tests/function_modifiers/test_delayed.py::test_delayed_without_power_mode_config_fails_with_helpful_error`
- `uv run ruff format --check hamilton/function_modifiers/delayed.py tests/function_modifiers/test_delayed.py`
- `uv run ruff check hamilton/function_modifiers/delayed.py tests/function_modifiers/test_delayed.py`

## Notes

Fixes #1135.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.