### PR TITLE
Bump sub-package versions and update extras for release

### DIFF
--- a/contrib/hamilton/contrib/version.py
+++ b/contrib/hamilton/contrib/version.py
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-VERSION = (0, 0, 8)
+VERSION = (0, 0, 9)

--- a/contrib/pyproject.toml
+++ b/contrib/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-hamilton-contrib"
-version = "0.0.8"  # Keep in sync with contrib/hamilton/contrib/version.py until this becomes dynamic
+version = "0.0.9"  # Keep in sync with contrib/hamilton/contrib/version.py until this becomes dynamic
 description = "Apache Hamilton's user contributed shared dataflow library."
 readme = "README.md"
 requires-python = ">=3.10, <4"

--- a/dev_tools/language_server/hamilton_lsp/__init__.py
+++ b/dev_tools/language_server/hamilton_lsp/__init__.py
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/dev_tools/language_server/pyproject.toml
+++ b/dev_tools/language_server/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-hamilton-lsp"
-version = "0.1.0"
+version = "0.2.0"
 description = "Apache Hamilton Language Server powering IDE features."
 readme = "README.md"
 requires-python = ">=3.10, <4"

--- a/ui/backend/pyproject.toml
+++ b/ui/backend/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-hamilton-ui"
-version = "0.0.17"
+version = "0.0.18"
 description = "Apache Hamilton UI tracking server for dataflow visualization and monitoring."
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10.1, <4"

--- a/ui/sdk/pyproject.toml
+++ b/ui/sdk/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-hamilton-sdk"
-version = "0.8.0"
+version = "0.9.0"
 description = "Apache Hamilton SDK for reading and writing to the Apache Hamilton backend APIs that support the UI."
 readme = "README.md"
 requires-python = ">=3.10, <4"

--- a/ui/sdk/src/hamilton_sdk/__init__.py
+++ b/ui/sdk/src/hamilton_sdk/__init__.py
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-__version__ = (0, 8, 0)
+__version__ = (0, 9, 0)


### PR DESCRIPTION
Branch to cut RC releases from.

## Changes
- apache-hamilton-sdk: 0.8.0 -> 0.9.0
- apache-hamilton-ui: 0.0.17 -> 0.0.18
- apache-hamilton-lsp: 0.1.0 -> 0.2.0
- apache-hamilton-contrib: 0.0.8 -> 0.0.9
- Update root pyproject.toml extras to point to apache-hamilton-{lsp,sdk,ui}

## How I tested this
- locally

## Notes
- this is what I'm going to cut releases from and vote on.

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
