### PR TITLE
Fix UI sdist to include tests, exclude untracked hamilton_ui/tests from wheel

### DIFF
--- a/ui/backend/pyproject.toml
+++ b/ui/backend/pyproject.toml
@@ -75,9 +75,10 @@ include = [
     "NOTICE",
     "DISCLAIMER",
     "hamilton_ui/build/**",
+    "tests/**",
 ]
 exclude = [
-    "tests/**",
+    "hamilton_ui/tests/**",
     ".git/**",
     "**/__pycache__/**",
     "**/*.pyc",


### PR DESCRIPTION
## Changes

- Include `tests/**` in `[tool.flit.sdist] include` so the source distribution contains tests (per Apache release policy: tests should be in sdist for voters to validate)
- Exclude `hamilton_ui/tests/**` from the wheel (this is an untracked directory that gets picked up by `flit build --no-use-vcs` but shouldn't be distributed)

## How I tested this

```bash
cd ui/backend && flit build --no-use-vcs

# Wheel has no test files
python -c "import zipfile; z=zipfile.ZipFile('dist/apache_hamilton_ui-0.0.18-py3-none-any.whl'); print([f for f in z.namelist() if 'tests/' in f])"
# []

# Sdist has test files
python -c "import tarfile; t=tarfile.open('dist/apache_hamilton_ui-0.0.18.tar.gz'); print([f.name for f in t.getmembers() if 'tests/' in f.name])"
# ['apache_hamilton_ui-0.0.18/tests/__init__.py', 'apache_hamilton_ui-0.0.18/tests/test_build.py']
```
