### PR TITLE
Add packaging to runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy",
+    "packaging",
     "pandas",
     "typing_extensions > 4.0.0",
     "typing_inspect",


### PR DESCRIPTION
## Problem

`hamilton/plugins/pandas_extensions.py` imports `from packaging.version import Version` (added in 4dbaf085 for pandas 2.2+ compatibility), but `packaging` was never added to the runtime `[project] dependencies`.

This worked previously because `pip` and `setuptools` both depend on `packaging`, so it's always present in environments that have either installed. However, bare `uv venv` environments (without `--seed`) don't include pip/setuptools, exposing the missing dependency.

## Fix

Add `packaging` to the core `dependencies` list in `pyproject.toml`.

## How I found this

Installing the built wheel in a fresh `uv venv` and running `examples/hamilton_ui` failed with:
```
ModuleNotFoundError: No module named 'packaging'
```
