### PR TITLE
Add Apache license headers to SDK CLI template files

### DIFF
--- a/scripts/verify_apache_artifacts.py
+++ b/scripts/verify_apache_artifacts.py
@@ -615,7 +615,7 @@ def cmd_twine_check(args) -> bool:
     """Verify wheel metadata with twine."""
     _print_section("Verifying Wheel Metadata with Twine")
 
-    wheel_pattern = f"{args.artifacts_dir}/apache_hamilton-*.whl"
+    wheel_pattern = f"{args.artifacts_dir}/apache_hamilton*.whl"
     wheel_files = glob.glob(wheel_pattern)
 
     if not wheel_files:

--- a/ui/sdk/src/hamilton_sdk/cli/templates/common/.env.jinja2
+++ b/ui/sdk/src/hamilton_sdk/cli/templates/common/.env.jinja2
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 # THIS FILE SHOULD NOT BE CHECKED INTO GIT! #
 # USE YOUR OWN SECRET-MANAGEMENT PLATFORM   #
 HAMILTON_API_KEY={{ api_key }}

--- a/ui/sdk/src/hamilton_sdk/cli/templates/common/README.md.jinja2
+++ b/ui/sdk/src/hamilton_sdk/cli/templates/common/README.md.jinja2
@@ -1,3 +1,22 @@
+<!--
+     Licensed to the Apache Software Foundation (ASF) under one
+     or more contributor license agreements.  See the NOTICE file
+     distributed with this work for additional information
+     regarding copyright ownership.  The ASF licenses this file
+     to you under the Apache License, Version 2.0 (the
+     "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing,
+     software distributed under the License is distributed on an
+     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+     KIND, either express or implied.  See the License for the
+     specific language governing permissions and limitations
+     under the License.
+-->
+
 # {{ template_name | replace('_', '\\_') }}
 
 {{ template_description | wordwrap(100) }}

--- a/ui/sdk/src/hamilton_sdk/cli/templates/common/requirements.txt.jinja2
+++ b/ui/sdk/src/hamilton_sdk/cli/templates/common/requirements.txt.jinja2
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 {{ requirements | join('\n') }}
 click
 hamilton-sdk

--- a/ui/sdk/src/hamilton_sdk/cli/templates/common/run.py.jinja2
+++ b/ui/sdk/src/hamilton_sdk/cli/templates/common/run.py.jinja2
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 import os
 import click
 import json

--- a/ui/sdk/src/hamilton_sdk/cli/templates/common/run.sh.jinja2
+++ b/ui/sdk/src/hamilton_sdk/cli/templates/common/run.sh.jinja2
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 # basic script to load up any necessary environment variables
 
 # Define the list of Python aliases to check


### PR DESCRIPTION
5 jinja2 template files in `ui/sdk/src/hamilton_sdk/cli/templates/common/` were missing Apache license headers, flagged by Apache RAT during sub-package release verification.

Files:
- `.env.jinja2`
- `README.md.jinja2`
- `requirements.txt.jinja2`
- `run.py.jinja2`
- `run.sh.jinja2`