### PR TITLE
Make sub-package verify scripts self-contained with full Apache checks

### DIFF
--- a/scripts/verification-sub-packages.sh
+++ b/scripts/verification-sub-packages.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# =============================================================================
+# Apache Hamilton Sub-Package Release Candidate Validation Script
+#
+# Validates sub-package release candidates by:
+#   1. Downloading artifacts from Apache SVN
+#   2. Verifying GPG signatures and SHA512 checksums
+#   3. Checking Apache license headers with Apache RAT
+#   4. Building from source tarballs
+#   5. Running functional verification for each package
+#
+# Prerequisites: svn, gpg, java (for RAT), uv, curl, flit
+#
+# Usage:
+#   ./verification-sub-packages.sh <rc>
+#   ./verification-sub-packages.sh 0           # validate RC0
+# =============================================================================
+
+set -euo pipefail
+
+RC="${1:-0}"
+
+SDK_VERSION="0.9.0"
+UI_VERSION="0.0.18"
+LSP_VERSION="0.2.0"
+CONTRIB_VERSION="0.0.9"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORK_DIR="hamilton-subpkgs-rc${RC}-validation"
+SVN_BASE="https://dist.apache.org/repos/dist/dev/incubator/hamilton"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+section() { echo -e "\n${GREEN}==============================================================================${NC}"; echo -e "  $1"; echo -e "${GREEN}==============================================================================${NC}\n"; }
+
+declare -A PKG_VERSIONS=(
+    ["sdk"]="$SDK_VERSION"
+    ["ui"]="$UI_VERSION"
+    ["lsp"]="$LSP_VERSION"
+    ["contrib"]="$CONTRIB_VERSION"
+)
+
+declare -A PKG_NAMES=(
+    ["sdk"]="apache-hamilton-sdk"
+    ["ui"]="apache-hamilton-ui"
+    ["lsp"]="apache-hamilton-lsp"
+    ["contrib"]="apache-hamilton-contrib"
+)
+
+# =============================================================================
+section "Step 1: Downloading Artifacts from SVN"
+# =============================================================================
+
+if [ -d "$WORK_DIR" ]; then
+    rm -rf "$WORK_DIR"
+fi
+mkdir -p "$WORK_DIR"
+
+for key in sdk ui lsp contrib; do
+    name="${PKG_NAMES[$key]}"
+    version="${PKG_VERSIONS[$key]}"
+    echo "Downloading ${name} ${version}-RC${RC}..."
+    svn export -q "${SVN_BASE}/${name}/${version}-RC${RC}/" "${WORK_DIR}/${key}/"
+done
+
+# =============================================================================
+section "Step 2: Verifying GPG Signatures and SHA512 Checksums"
+# =============================================================================
+
+curl -sO https://downloads.apache.org/incubator/hamilton/KEYS
+gpg --import KEYS 2>&1 | tail -1
+
+for key in sdk ui lsp contrib; do
+    echo ""
+    echo "--- ${PKG_NAMES[$key]} ---"
+    for artifact in ${WORK_DIR}/${key}/*.tar.gz ${WORK_DIR}/${key}/*.whl; do
+        [ -f "$artifact" ] || continue
+        gpg --verify "${artifact}.asc" "$artifact" 2>&1 | grep -E "Good signature|BAD"
+        expected=$(cat "${artifact}.sha512")
+        actual=$(shasum -a 512 "$artifact" | awk '{print $1}')
+        if [ "$expected" = "$actual" ]; then
+            echo "  ✓ SHA512 OK: $(basename "$artifact")"
+        else
+            echo "  ✗ SHA512 MISMATCH: $(basename "$artifact")"
+            exit 1
+        fi
+    done
+done
+
+# =============================================================================
+section "Step 3: Checking License Headers (Apache RAT)"
+# =============================================================================
+
+if [ ! -f "apache-rat-0.15.jar" ]; then
+    curl -sO https://repo1.maven.org/maven2/org/apache/rat/apache-rat/0.15/apache-rat-0.15.jar
+fi
+
+for key in sdk ui lsp contrib; do
+    src_tar=$(ls ${WORK_DIR}/${key}/*-src.tar.gz 2>/dev/null | head -1)
+    echo "--- ${PKG_NAMES[$key]} ---"
+    extract_dir="/tmp/rat-$$-${key}"
+    mkdir -p "$extract_dir"
+    tar xzf "$src_tar" -C "$extract_dir"
+    unknown=$(java -jar apache-rat-0.15.jar -d "$extract_dir" 2>&1 | grep -c "!?????" || true)
+    if [ "$unknown" -eq 0 ]; then
+        echo "  ✓ All files have approved licenses"
+    else
+        echo "  ✗ ${unknown} file(s) missing license headers"
+        java -jar apache-rat-0.15.jar -d "$extract_dir" 2>&1 | grep "!?????"
+        exit 1
+    fi
+    rm -rf "$extract_dir"
+done
+
+# =============================================================================
+section "Step 4: Building from Source"
+# =============================================================================
+
+for key in sdk ui lsp contrib; do
+    src_tar=$(ls ${WORK_DIR}/${key}/*-src.tar.gz 2>/dev/null | head -1)
+    echo "--- ${PKG_NAMES[$key]} ---"
+    extract_dir="/tmp/build-$$-${key}"
+    mkdir -p "$extract_dir"
+    tar xzf "$src_tar" -C "$extract_dir"
+    build_dir=$(ls -d ${extract_dir}/*/ | head -1)
+    if (cd "$build_dir" && flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
+        echo "  ✓ Built from source"
+    else
+        echo "  ✗ Build failed"
+        exit 1
+    fi
+    rm -rf "$extract_dir"
+done
+
+# =============================================================================
+section "Step 5: Functional Verification"
+# =============================================================================
+
+echo "Running individual package verification scripts..."
+echo ""
+
+bash "${SCRIPT_DIR}/verify-sub-packages/verify_sdk.sh" "$SDK_VERSION" "${WORK_DIR}/sdk"
+echo ""
+bash "${SCRIPT_DIR}/verify-sub-packages/verify_ui.sh" "$UI_VERSION" "${WORK_DIR}/ui"
+echo ""
+bash "${SCRIPT_DIR}/verify-sub-packages/verify_lsp.sh" "$LSP_VERSION" "${WORK_DIR}/lsp"
+echo ""
+bash "${SCRIPT_DIR}/verify-sub-packages/verify_contrib.sh" "$CONTRIB_VERSION" "${WORK_DIR}/contrib"
+
+# =============================================================================
+section "All Checks Passed!"
+# =============================================================================
+
+echo -e "${GREEN}All sub-package RCs validated successfully.${NC}"
+echo ""
+echo "Packages verified:"
+echo "  apache-hamilton-sdk     ${SDK_VERSION}-RC${RC}"
+echo "  apache-hamilton-ui      ${UI_VERSION}-RC${RC}"
+echo "  apache-hamilton-lsp     ${LSP_VERSION}-RC${RC}"
+echo "  apache-hamilton-contrib ${CONTRIB_VERSION}-RC${RC}"

--- a/scripts/verify-sub-packages/verify_all.sh
+++ b/scripts/verify-sub-packages/verify_all.sh
@@ -19,14 +19,16 @@
 # Verify all sub-packages install together and work.
 #
 # Usage:
-#   ./verify_all.sh <hamilton_version> <sdk_version> <ui_version> <lsp_version> <contrib_version>
+#   ./verify_all.sh <hamilton_version> <sdk_version> <ui_version> <lsp_version> <contrib_version> [artifacts_base_dir]
 #   ./verify_all.sh 1.90.0 0.9.0 0.0.18 0.2.0 0.0.9
+#   ./verify_all.sh 1.90.0 0.9.0 0.0.18 0.2.0 0.0.9 ./artifacts
 
 set -euo pipefail
 
-if [ $# -ne 5 ]; then
-    echo "Usage: $0 <hamilton_version> <sdk_version> <ui_version> <lsp_version> <contrib_version>"
+if [ $# -lt 5 ]; then
+    echo "Usage: $0 <hamilton_version> <sdk_version> <ui_version> <lsp_version> <contrib_version> [artifacts_base_dir]"
     echo "Example: $0 1.90.0 0.9.0 0.0.18 0.2.0 0.0.9"
+    echo "Example: $0 1.90.0 0.9.0 0.0.18 0.2.0 0.0.9 ./downloaded-artifacts"
     exit 1
 fi
 
@@ -35,6 +37,7 @@ SDK_VERSION="$2"
 UI_VERSION="$3"
 LSP_VERSION="$4"
 CONTRIB_VERSION="$5"
+ARTIFACTS_DIR="${6:-}"
 
 VENV_DIR="/tmp/verify-all-$$"
 echo "=== Verifying all sub-packages together ==="
@@ -45,12 +48,21 @@ source "$VENV_DIR/bin/activate"
 
 # Install all
 echo "Installing all packages..."
-uv pip install -q \
-    "apache-hamilton==${HAMILTON_VERSION}" \
-    "apache-hamilton-sdk==${SDK_VERSION}" \
-    "apache-hamilton-ui==${UI_VERSION}" \
-    "apache-hamilton-lsp==${LSP_VERSION}" \
-    "apache-hamilton-contrib==${CONTRIB_VERSION}"
+if [ -n "$ARTIFACTS_DIR" ]; then
+    uv pip install -q \
+        "$ARTIFACTS_DIR"/apache_hamilton_sdk-*.whl \
+        "$ARTIFACTS_DIR"/apache_hamilton_ui-*.whl \
+        "$ARTIFACTS_DIR"/apache_hamilton_lsp-*.whl \
+        "$ARTIFACTS_DIR"/apache_hamilton_contrib-*.whl \
+        "apache-hamilton==${HAMILTON_VERSION}"
+else
+    uv pip install -q \
+        "apache-hamilton==${HAMILTON_VERSION}" \
+        "apache-hamilton-sdk==${SDK_VERSION}" \
+        "apache-hamilton-ui==${UI_VERSION}" \
+        "apache-hamilton-lsp==${LSP_VERSION}" \
+        "apache-hamilton-contrib==${CONTRIB_VERSION}"
+fi
 
 # Verify all imports
 echo "Checking imports..."

--- a/scripts/verify-sub-packages/verify_contrib.sh
+++ b/scripts/verify-sub-packages/verify_contrib.sh
@@ -16,47 +16,135 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Verify apache-hamilton-contrib installs and dataflows are importable.
+# Fully self-contained verification of apache-hamilton-contrib.
+# Downloads from SVN (or uses local artifacts), verifies signatures,
+# checks licenses, builds from source, and runs functional tests.
 #
 # Usage:
-#   ./verify_contrib.sh [version]
-#   ./verify_contrib.sh 0.0.9
+#   ./verify_contrib.sh <version> <rc>                    # download from SVN
+#   ./verify_contrib.sh <version> <rc> <artifacts_dir>    # use local artifacts
+#   ./verify_contrib.sh 0.0.9 0
+#   ./verify_contrib.sh 0.0.9 0 ./contrib-rc0
 
 set -euo pipefail
 
 VERSION="${1:-}"
-if [ -z "$VERSION" ]; then
-    echo "Usage: $0 <version>"
+RC="${2:-}"
+ARTIFACTS_DIR="${3:-}"
+
+if [ -z "$VERSION" ] || [ -z "$RC" ]; then
+    echo "Usage: $0 <version> <rc> [artifacts_dir]"
     exit 1
 fi
 
-VENV_DIR="/tmp/verify-contrib-$$"
-echo "=== Verifying apache-hamilton-contrib ${VERSION} ==="
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PACKAGE="apache-hamilton-contrib"
+SRC_TAR="${PACKAGE}-${VERSION}-incubating-src.tar.gz"
+WHEEL="apache_hamilton_contrib-${VERSION}-py3-none-any.whl"
 
-# Create isolated environment
+echo "=== Verifying ${PACKAGE} ${VERSION}-RC${RC} ==="
+
+# --- Step 1: Get artifacts ---
+if [ -z "$ARTIFACTS_DIR" ]; then
+    ARTIFACTS_DIR="/tmp/verify-contrib-artifacts-$$"
+    echo "Downloading from SVN..."
+    svn export -q "https://dist.apache.org/repos/dist/dev/incubator/hamilton/${PACKAGE}/${VERSION}-RC${RC}/" "$ARTIFACTS_DIR"
+fi
+
+echo "Artifacts: $ARTIFACTS_DIR"
+ls "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl 2>/dev/null || { echo "ERROR: No artifacts found"; exit 1; }
+
+# --- Step 2: GPG signatures ---
+echo ""
+echo "--- Verifying GPG signatures ---"
+curl -sO https://downloads.apache.org/incubator/hamilton/KEYS
+gpg --import KEYS 2>/dev/null || true
+
+for artifact in "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl; do
+    [ -f "$artifact" ] || continue
+    if gpg --verify "${artifact}.asc" "$artifact" 2>&1 | grep -q "Good signature"; then
+        echo "  ✓ GPG OK: $(basename "$artifact")"
+    else
+        echo "  ✗ GPG FAILED: $(basename "$artifact")"
+        exit 1
+    fi
+done
+
+# --- Step 3: SHA512 checksums ---
+echo ""
+echo "--- Verifying SHA512 checksums ---"
+for artifact in "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl; do
+    [ -f "$artifact" ] || continue
+    expected=$(cat "${artifact}.sha512")
+    actual=$(shasum -a 512 "$artifact" | awk '{print $1}')
+    if [ "$expected" = "$actual" ]; then
+        echo "  ✓ SHA512 OK: $(basename "$artifact")"
+    else
+        echo "  ✗ SHA512 MISMATCH: $(basename "$artifact")"
+        exit 1
+    fi
+done
+
+# --- Step 4: Apache RAT license check ---
+echo ""
+echo "--- Checking license headers (Apache RAT) ---"
+RAT_JAR="${SCRIPT_DIR}/../apache-rat-0.15.jar"
+if [ ! -f "$RAT_JAR" ]; then
+    RAT_JAR="/tmp/apache-rat-0.15.jar"
+    [ -f "$RAT_JAR" ] || curl -sO -o "$RAT_JAR" https://repo1.maven.org/maven2/org/apache/rat/apache-rat/0.15/apache-rat-0.15.jar
+fi
+RAT_EXCLUDES="${SCRIPT_DIR}/../../.rat-excludes"
+
+extract_dir="/tmp/rat-contrib-$$"
+mkdir -p "$extract_dir"
+tar xzf "$ARTIFACTS_DIR/$SRC_TAR" -C "$extract_dir"
+unknown=$(java -jar "$RAT_JAR" -E "$RAT_EXCLUDES" -d "$extract_dir" 2>&1 | grep -c "!?????" || true)
+if [ "$unknown" -eq 0 ]; then
+    echo "  ✓ All files have approved licenses"
+else
+    echo "  ✗ ${unknown} file(s) missing license headers"
+    java -jar "$RAT_JAR" -E "$RAT_EXCLUDES" -d "$extract_dir" 2>&1 | grep "!?????"
+    rm -rf "$extract_dir"
+    exit 1
+fi
+rm -rf "$extract_dir"
+
+# --- Step 5: Build from source ---
+echo ""
+echo "--- Building from source ---"
+build_dir="/tmp/build-contrib-$$"
+mkdir -p "$build_dir"
+tar xzf "$ARTIFACTS_DIR/$SRC_TAR" -C "$build_dir"
+src_dir=$(ls -d ${build_dir}/*/ | head -1)
+if (cd "$src_dir" && flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
+    echo "  ✓ Built from source successfully"
+else
+    echo "  ✗ Build from source failed"
+    rm -rf "$build_dir"
+    exit 1
+fi
+rm -rf "$build_dir"
+
+# --- Step 6: Functional verification ---
+echo ""
+echo "--- Functional verification ---"
+VENV_DIR="/tmp/verify-contrib-func-$$"
 uv venv "$VENV_DIR" --python 3.12 -q
 source "$VENV_DIR/bin/activate"
 
-# Install
-echo "Installing..."
-uv pip install -q apache-hamilton "apache-hamilton-contrib==${VERSION}"
+uv pip install -q "$ARTIFACTS_DIR/$WHEEL" apache-hamilton
 
-# Version check
-echo "Checking version..."
-python -c "import importlib.metadata; v = importlib.metadata.version('apache-hamilton-contrib'); assert v == '${VERSION}', f'Got {v}'; print(f'  Version: {v}')"
+python -c "import importlib.metadata; assert importlib.metadata.version('apache-hamilton-contrib') == '${VERSION}'"
+echo "  ✓ Version correct"
 
-# Import check
-echo "Checking imports..."
-python -c "
-from hamilton.contrib import version
-print(f'  version.py VERSION: {version.VERSION}')
-import hamilton.contrib.user
-import hamilton.contrib.user.zilto
-print('  Namespace imports: OK')
-"
+python -c "from hamilton.contrib import version; assert version.VERSION == tuple(int(x) for x in '${VERSION}'.split('.'))"
+echo "  ✓ version.py correct"
 
-# Cleanup
+python -c "import hamilton.contrib.user; import hamilton.contrib.user.zilto"
+echo "  ✓ Namespace imports OK"
+
 deactivate
 rm -rf "$VENV_DIR"
 
-echo "=== apache-hamilton-contrib ${VERSION}: PASSED ==="
+echo ""
+echo "=== ${PACKAGE} ${VERSION}-RC${RC}: ALL CHECKS PASSED ==="

--- a/scripts/verify-sub-packages/verify_lsp.sh
+++ b/scripts/verify-sub-packages/verify_lsp.sh
@@ -16,37 +16,128 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Verify apache-hamilton-lsp installs and responds to LSP initialize.
+# Fully self-contained verification of apache-hamilton-lsp.
+# Downloads from SVN (or uses local artifacts), verifies signatures,
+# checks licenses, builds from source, and runs functional tests.
 #
 # Usage:
-#   ./verify_lsp.sh [version]
-#   ./verify_lsp.sh 0.2.0
+#   ./verify_lsp.sh <version> <rc>                    # download from SVN
+#   ./verify_lsp.sh <version> <rc> <artifacts_dir>    # use local artifacts
+#   ./verify_lsp.sh 0.2.0 0
+#   ./verify_lsp.sh 0.2.0 0 ./lsp-rc0
 
 set -euo pipefail
 
 VERSION="${1:-}"
-if [ -z "$VERSION" ]; then
-    echo "Usage: $0 <version>"
+RC="${2:-}"
+ARTIFACTS_DIR="${3:-}"
+
+if [ -z "$VERSION" ] || [ -z "$RC" ]; then
+    echo "Usage: $0 <version> <rc> [artifacts_dir]"
     exit 1
 fi
 
-VENV_DIR="/tmp/verify-lsp-$$"
-echo "=== Verifying apache-hamilton-lsp ${VERSION} ==="
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PACKAGE="apache-hamilton-lsp"
+SRC_TAR="${PACKAGE}-${VERSION}-incubating-src.tar.gz"
+WHEEL="apache_hamilton_lsp-${VERSION}-py3-none-any.whl"
 
-# Create isolated environment
+echo "=== Verifying ${PACKAGE} ${VERSION}-RC${RC} ==="
+
+# --- Step 1: Get artifacts ---
+if [ -z "$ARTIFACTS_DIR" ]; then
+    ARTIFACTS_DIR="/tmp/verify-lsp-artifacts-$$"
+    echo "Downloading from SVN..."
+    svn export -q "https://dist.apache.org/repos/dist/dev/incubator/hamilton/${PACKAGE}/${VERSION}-RC${RC}/" "$ARTIFACTS_DIR"
+fi
+
+echo "Artifacts: $ARTIFACTS_DIR"
+ls "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl 2>/dev/null || { echo "ERROR: No artifacts found"; exit 1; }
+
+# --- Step 2: GPG signatures ---
+echo ""
+echo "--- Verifying GPG signatures ---"
+curl -sO https://downloads.apache.org/incubator/hamilton/KEYS
+gpg --import KEYS 2>/dev/null || true
+
+for artifact in "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl; do
+    [ -f "$artifact" ] || continue
+    if gpg --verify "${artifact}.asc" "$artifact" 2>&1 | grep -q "Good signature"; then
+        echo "  ✓ GPG OK: $(basename "$artifact")"
+    else
+        echo "  ✗ GPG FAILED: $(basename "$artifact")"
+        exit 1
+    fi
+done
+
+# --- Step 3: SHA512 checksums ---
+echo ""
+echo "--- Verifying SHA512 checksums ---"
+for artifact in "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl; do
+    [ -f "$artifact" ] || continue
+    expected=$(cat "${artifact}.sha512")
+    actual=$(shasum -a 512 "$artifact" | awk '{print $1}')
+    if [ "$expected" = "$actual" ]; then
+        echo "  ✓ SHA512 OK: $(basename "$artifact")"
+    else
+        echo "  ✗ SHA512 MISMATCH: $(basename "$artifact")"
+        exit 1
+    fi
+done
+
+# --- Step 4: Apache RAT license check ---
+echo ""
+echo "--- Checking license headers (Apache RAT) ---"
+RAT_JAR="${SCRIPT_DIR}/../apache-rat-0.15.jar"
+if [ ! -f "$RAT_JAR" ]; then
+    RAT_JAR="/tmp/apache-rat-0.15.jar"
+    [ -f "$RAT_JAR" ] || curl -sO -o "$RAT_JAR" https://repo1.maven.org/maven2/org/apache/rat/apache-rat/0.15/apache-rat-0.15.jar
+fi
+RAT_EXCLUDES="${SCRIPT_DIR}/../../.rat-excludes"
+
+extract_dir="/tmp/rat-lsp-$$"
+mkdir -p "$extract_dir"
+tar xzf "$ARTIFACTS_DIR/$SRC_TAR" -C "$extract_dir"
+unknown=$(java -jar "$RAT_JAR" -E "$RAT_EXCLUDES" -d "$extract_dir" 2>&1 | grep -c "!?????" || true)
+if [ "$unknown" -eq 0 ]; then
+    echo "  ✓ All files have approved licenses"
+else
+    echo "  ✗ ${unknown} file(s) missing license headers"
+    java -jar "$RAT_JAR" -E "$RAT_EXCLUDES" -d "$extract_dir" 2>&1 | grep "!?????"
+    rm -rf "$extract_dir"
+    exit 1
+fi
+rm -rf "$extract_dir"
+
+# --- Step 5: Build from source ---
+echo ""
+echo "--- Building from source ---"
+build_dir="/tmp/build-lsp-$$"
+mkdir -p "$build_dir"
+tar xzf "$ARTIFACTS_DIR/$SRC_TAR" -C "$build_dir"
+src_dir=$(ls -d ${build_dir}/*/ | head -1)
+if (cd "$src_dir" && flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
+    echo "  ✓ Built from source successfully"
+else
+    echo "  ✗ Build from source failed"
+    rm -rf "$build_dir"
+    exit 1
+fi
+rm -rf "$build_dir"
+
+# --- Step 6: Functional verification ---
+echo ""
+echo "--- Functional verification ---"
+VENV_DIR="/tmp/verify-lsp-func-$$"
 uv venv "$VENV_DIR" --python 3.12 -q
 source "$VENV_DIR/bin/activate"
 
-# Install
-echo "Installing..."
-uv pip install -q "apache-hamilton[visualization]" "apache-hamilton-lsp==${VERSION}"
+uv pip install -q "$ARTIFACTS_DIR/$WHEEL" "apache-hamilton[visualization]"
 
-# Version check
-echo "Checking version..."
-python -c "from hamilton_lsp import __version__; assert __version__ == '${VERSION}', f'Got {__version__}'; print(f'  Version: {__version__}')"
+python -c "from hamilton_lsp import __version__; assert __version__ == '${VERSION}'"
+echo "  ✓ Version correct"
 
-# LSP initialize test
-echo "Checking LSP responds to initialize..."
+# LSP initialize request
 python -c "
 import subprocess, json, os
 
@@ -65,7 +156,6 @@ msg = f'Content-Length: {len(request)}\r\n\r\n{request}'
 proc.stdin.write(msg.encode())
 proc.stdin.flush()
 
-# Read response headers until blank line
 while True:
     line = proc.stdout.readline()
     if line.strip() == b'':
@@ -80,12 +170,11 @@ proc.wait()
 resp = json.loads(body)
 caps = resp.get('result', {}).get('capabilities', {})
 assert 'textDocumentSync' in caps, f'Missing capabilities, got: {list(caps.keys())}'
-print(f'  Capabilities: {list(caps.keys())}')
-print('  LSP initialize: OK')
 "
+echo "  ✓ LSP responds to initialize"
 
-# Cleanup
 deactivate
 rm -rf "$VENV_DIR"
 
-echo "=== apache-hamilton-lsp ${VERSION}: PASSED ==="
+echo ""
+echo "=== ${PACKAGE} ${VERSION}-RC${RC}: ALL CHECKS PASSED ==="

--- a/scripts/verify-sub-packages/verify_sdk.sh
+++ b/scripts/verify-sub-packages/verify_sdk.sh
@@ -16,50 +16,135 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Verify apache-hamilton-sdk installs and works.
+# Fully self-contained verification of apache-hamilton-sdk.
+# Downloads from SVN (or uses local artifacts), verifies signatures,
+# checks licenses, builds from source, and runs functional tests.
 #
 # Usage:
-#   ./verify_sdk.sh [version]
-#   ./verify_sdk.sh 0.9.0
+#   ./verify_sdk.sh <version> <rc>                    # download from SVN
+#   ./verify_sdk.sh <version> <rc> <artifacts_dir>    # use local artifacts
+#   ./verify_sdk.sh 0.9.0 0
+#   ./verify_sdk.sh 0.9.0 0 ./sdk-rc0
 
 set -euo pipefail
 
 VERSION="${1:-}"
-if [ -z "$VERSION" ]; then
-    echo "Usage: $0 <version>"
+RC="${2:-}"
+ARTIFACTS_DIR="${3:-}"
+
+if [ -z "$VERSION" ] || [ -z "$RC" ]; then
+    echo "Usage: $0 <version> <rc> [artifacts_dir]"
     exit 1
 fi
 
-VENV_DIR="/tmp/verify-sdk-$$"
-echo "=== Verifying apache-hamilton-sdk ${VERSION} ==="
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PACKAGE="apache-hamilton-sdk"
+SRC_TAR="${PACKAGE}-${VERSION}-incubating-src.tar.gz"
+WHEEL="apache_hamilton_sdk-${VERSION}-py3-none-any.whl"
 
-# Create isolated environment
+echo "=== Verifying ${PACKAGE} ${VERSION}-RC${RC} ==="
+
+# --- Step 1: Get artifacts ---
+if [ -z "$ARTIFACTS_DIR" ]; then
+    ARTIFACTS_DIR="/tmp/verify-sdk-artifacts-$$"
+    echo "Downloading from SVN..."
+    svn export -q "https://dist.apache.org/repos/dist/dev/incubator/hamilton/${PACKAGE}/${VERSION}-RC${RC}/" "$ARTIFACTS_DIR"
+fi
+
+echo "Artifacts: $ARTIFACTS_DIR"
+ls "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl 2>/dev/null || { echo "ERROR: No artifacts found"; exit 1; }
+
+# --- Step 2: GPG signatures ---
+echo ""
+echo "--- Verifying GPG signatures ---"
+curl -sO https://downloads.apache.org/incubator/hamilton/KEYS
+gpg --import KEYS 2>/dev/null || true
+
+for artifact in "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl; do
+    [ -f "$artifact" ] || continue
+    if gpg --verify "${artifact}.asc" "$artifact" 2>&1 | grep -q "Good signature"; then
+        echo "  ✓ GPG OK: $(basename "$artifact")"
+    else
+        echo "  ✗ GPG FAILED: $(basename "$artifact")"
+        exit 1
+    fi
+done
+
+# --- Step 3: SHA512 checksums ---
+echo ""
+echo "--- Verifying SHA512 checksums ---"
+for artifact in "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl; do
+    [ -f "$artifact" ] || continue
+    expected=$(cat "${artifact}.sha512")
+    actual=$(shasum -a 512 "$artifact" | awk '{print $1}')
+    if [ "$expected" = "$actual" ]; then
+        echo "  ✓ SHA512 OK: $(basename "$artifact")"
+    else
+        echo "  ✗ SHA512 MISMATCH: $(basename "$artifact")"
+        exit 1
+    fi
+done
+
+# --- Step 4: Apache RAT license check ---
+echo ""
+echo "--- Checking license headers (Apache RAT) ---"
+RAT_JAR="${SCRIPT_DIR}/../apache-rat-0.15.jar"
+if [ ! -f "$RAT_JAR" ]; then
+    RAT_JAR="/tmp/apache-rat-0.15.jar"
+    [ -f "$RAT_JAR" ] || curl -sO -o "$RAT_JAR" https://repo1.maven.org/maven2/org/apache/rat/apache-rat/0.15/apache-rat-0.15.jar
+fi
+RAT_EXCLUDES="${SCRIPT_DIR}/../../.rat-excludes"
+
+extract_dir="/tmp/rat-sdk-$$"
+mkdir -p "$extract_dir"
+tar xzf "$ARTIFACTS_DIR/$SRC_TAR" -C "$extract_dir"
+unknown=$(java -jar "$RAT_JAR" -E "$RAT_EXCLUDES" -d "$extract_dir" 2>&1 | grep -c "!?????" || true)
+if [ "$unknown" -eq 0 ]; then
+    echo "  ✓ All files have approved licenses"
+else
+    echo "  ✗ ${unknown} file(s) missing license headers"
+    java -jar "$RAT_JAR" -d "$extract_dir" 2>&1 | grep "!?????"
+    rm -rf "$extract_dir"
+    exit 1
+fi
+rm -rf "$extract_dir"
+
+# --- Step 5: Build from source ---
+echo ""
+echo "--- Building from source ---"
+build_dir="/tmp/build-sdk-$$"
+mkdir -p "$build_dir"
+tar xzf "$ARTIFACTS_DIR/$SRC_TAR" -C "$build_dir"
+src_dir=$(ls -d ${build_dir}/*/ | head -1)
+if (cd "$src_dir" && flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
+    echo "  ✓ Built from source successfully"
+else
+    echo "  ✗ Build from source failed"
+    rm -rf "$build_dir"
+    exit 1
+fi
+rm -rf "$build_dir"
+
+# --- Step 6: Functional verification ---
+echo ""
+echo "--- Functional verification ---"
+VENV_DIR="/tmp/verify-sdk-func-$$"
 uv venv "$VENV_DIR" --python 3.12 -q
 source "$VENV_DIR/bin/activate"
 
-# Install
-echo "Installing..."
-uv pip install -q apache-hamilton "apache-hamilton-sdk==${VERSION}"
+uv pip install -q "$ARTIFACTS_DIR/$WHEEL" apache-hamilton
 
-# Version check
-echo "Checking version..."
-python -c "import hamilton_sdk; assert hamilton_sdk.__version__ == tuple(int(x) for x in '${VERSION}'.split('.')), f'Got {hamilton_sdk.__version__}'; print(f'  Version: {hamilton_sdk.__version__}')"
+python -c "import hamilton_sdk; assert hamilton_sdk.__version__ == tuple(int(x) for x in '${VERSION}'.split('.')), f'Got {hamilton_sdk.__version__}'"
+echo "  ✓ Version correct"
 
-# Import check
-echo "Checking imports..."
-python -c "
-from hamilton_sdk.adapters import HamiltonTracker
-from hamilton_sdk.tracking import runs
-print('  Imports: OK')
-"
+python -c "from hamilton_sdk.adapters import HamiltonTracker; from hamilton_sdk.tracking import runs"
+echo "  ✓ Imports OK"
 
-# CLI check
-echo "Checking CLI..."
 python -m hamilton_sdk.cli.cli --help > /dev/null
-echo "  CLI: OK"
+echo "  ✓ CLI OK"
 
-# Cleanup
 deactivate
 rm -rf "$VENV_DIR"
 
-echo "=== apache-hamilton-sdk ${VERSION}: PASSED ==="
+echo ""
+echo "=== ${PACKAGE} ${VERSION}-RC${RC}: ALL CHECKS PASSED ==="

--- a/scripts/verify-sub-packages/verify_ui.sh
+++ b/scripts/verify-sub-packages/verify_ui.sh
@@ -16,68 +16,167 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Verify apache-hamilton-ui installs, starts in mini mode, and accepts SDK data.
+# Fully self-contained verification of apache-hamilton-ui.
+# Downloads from SVN (or uses local artifacts), verifies signatures,
+# checks licenses, builds from source, and runs functional tests.
 #
 # Usage:
-#   ./verify_ui.sh [version]
-#   ./verify_ui.sh 0.0.18
+#   ./verify_ui.sh <version> <rc>                    # download from SVN
+#   ./verify_ui.sh <version> <rc> <artifacts_dir>    # use local artifacts
+#   ./verify_ui.sh 0.0.18 0
+#   ./verify_ui.sh 0.0.18 0 ./ui-rc0
 
 set -euo pipefail
 
 VERSION="${1:-}"
-if [ -z "$VERSION" ]; then
-    echo "Usage: $0 <version>"
+RC="${2:-}"
+ARTIFACTS_DIR="${3:-}"
+
+if [ -z "$VERSION" ] || [ -z "$RC" ]; then
+    echo "Usage: $0 <version> <rc> [artifacts_dir]"
     exit 1
 fi
 
-VENV_DIR="/tmp/verify-ui-$$"
-HAMILTON_BASE_DIR="/tmp/verify-hamilton-ui-$$"
-PORT=8241
-echo "=== Verifying apache-hamilton-ui ${VERSION} ==="
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PACKAGE="apache-hamilton-ui"
+SRC_TAR="${PACKAGE}-${VERSION}-incubating-src.tar.gz"
+WHEEL="apache_hamilton_ui-${VERSION}-py3-none-any.whl"
 
-# Create isolated environment
+echo "=== Verifying ${PACKAGE} ${VERSION}-RC${RC} ==="
+
+# --- Step 1: Get artifacts ---
+if [ -z "$ARTIFACTS_DIR" ]; then
+    ARTIFACTS_DIR="/tmp/verify-ui-artifacts-$$"
+    echo "Downloading from SVN..."
+    svn export -q "https://dist.apache.org/repos/dist/dev/incubator/hamilton/${PACKAGE}/${VERSION}-RC${RC}/" "$ARTIFACTS_DIR"
+fi
+
+echo "Artifacts: $ARTIFACTS_DIR"
+ls "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl 2>/dev/null || { echo "ERROR: No artifacts found"; exit 1; }
+
+# --- Step 2: GPG signatures ---
+echo ""
+echo "--- Verifying GPG signatures ---"
+curl -sO https://downloads.apache.org/incubator/hamilton/KEYS
+gpg --import KEYS 2>/dev/null || true
+
+for artifact in "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl; do
+    [ -f "$artifact" ] || continue
+    if gpg --verify "${artifact}.asc" "$artifact" 2>&1 | grep -q "Good signature"; then
+        echo "  ✓ GPG OK: $(basename "$artifact")"
+    else
+        echo "  ✗ GPG FAILED: $(basename "$artifact")"
+        exit 1
+    fi
+done
+
+# --- Step 3: SHA512 checksums ---
+echo ""
+echo "--- Verifying SHA512 checksums ---"
+for artifact in "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl; do
+    [ -f "$artifact" ] || continue
+    expected=$(cat "${artifact}.sha512")
+    actual=$(shasum -a 512 "$artifact" | awk '{print $1}')
+    if [ "$expected" = "$actual" ]; then
+        echo "  ✓ SHA512 OK: $(basename "$artifact")"
+    else
+        echo "  ✗ SHA512 MISMATCH: $(basename "$artifact")"
+        exit 1
+    fi
+done
+
+# --- Step 4: Apache RAT license check ---
+echo ""
+echo "--- Checking license headers (Apache RAT) ---"
+RAT_JAR="${SCRIPT_DIR}/../apache-rat-0.15.jar"
+if [ ! -f "$RAT_JAR" ]; then
+    RAT_JAR="/tmp/apache-rat-0.15.jar"
+    [ -f "$RAT_JAR" ] || curl -sO -o "$RAT_JAR" https://repo1.maven.org/maven2/org/apache/rat/apache-rat/0.15/apache-rat-0.15.jar
+fi
+RAT_EXCLUDES="${SCRIPT_DIR}/../../.rat-excludes"
+
+extract_dir="/tmp/rat-ui-$$"
+mkdir -p "$extract_dir"
+tar xzf "$ARTIFACTS_DIR/$SRC_TAR" -C "$extract_dir"
+unknown=$(java -jar "$RAT_JAR" -E "$RAT_EXCLUDES" -d "$extract_dir" 2>&1 | grep -c "!?????" || true)
+if [ "$unknown" -eq 0 ]; then
+    echo "  ✓ All files have approved licenses"
+else
+    echo "  ✗ ${unknown} file(s) missing license headers"
+    java -jar "$RAT_JAR" -E "$RAT_EXCLUDES" -d "$extract_dir" 2>&1 | grep "!?????"
+    rm -rf "$extract_dir"
+    exit 1
+fi
+rm -rf "$extract_dir"
+
+# --- Step 5: Build from source ---
+echo ""
+echo "--- Building from source ---"
+build_dir="/tmp/build-ui-$$"
+mkdir -p "$build_dir"
+tar xzf "$ARTIFACTS_DIR/$SRC_TAR" -C "$build_dir"
+src_dir=$(ls -d ${build_dir}/*/ | head -1)
+if (cd "$src_dir" && flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
+    echo "  ✓ Built from source successfully"
+else
+    echo "  ✗ Build from source failed"
+    rm -rf "$build_dir"
+    exit 1
+fi
+rm -rf "$build_dir"
+
+# --- Step 6: Functional verification ---
+echo ""
+echo "--- Functional verification ---"
+VENV_DIR="/tmp/verify-ui-func-$$"
+HAMILTON_BASE_DIR="/tmp/verify-ui-data-$$"
+PORT=8241
+
 uv venv "$VENV_DIR" --python 3.12 -q
 source "$VENV_DIR/bin/activate"
 
-# Install
-echo "Installing..."
-uv pip install -q apache-hamilton "apache-hamilton-ui==${VERSION}"
+uv pip install -q "$ARTIFACTS_DIR/$WHEEL" apache-hamilton packaging
 
-# Version check
-echo "Checking version..."
-python -c "import importlib.metadata; v = importlib.metadata.version('apache-hamilton-ui'); assert v == '${VERSION}', f'Got {v}'; print(f'  Version: {v}')"
+python -c "import importlib.metadata; assert importlib.metadata.version('apache-hamilton-ui') == '${VERSION}'"
+echo "  ✓ Version correct"
 
 # Start server in mini mode
-echo "Starting server in mini mode..."
 mkdir -p "$HAMILTON_BASE_DIR/blobs" "$HAMILTON_BASE_DIR/db"
-HAMILTON_BASE_DIR="$HAMILTON_BASE_DIR" python -m hamilton.cli ui --settings-file mini --no-open --port $PORT &
-SERVER_PID=$!
-sleep 5
+HAMILTON_BASE_DIR="$HAMILTON_BASE_DIR" python -m hamilton.cli ui --settings-file mini --no-open --port $PORT > /dev/null 2>&1 &
+UI_PID=$!
+
+# Wait for server to be ready
+echo "  Waiting for server..."
+for i in $(seq 1 15); do
+    if python -c "import urllib.request; urllib.request.urlopen('http://localhost:${PORT}/api/ping')" 2>/dev/null; then
+        break
+    fi
+    sleep 2
+done
 
 # Health check
-echo "Checking health endpoint..."
-HEALTH=$(python -c "import urllib.request; print(urllib.request.urlopen('http://localhost:${PORT}/api/ping').read().decode())")
-if [ "$HEALTH" = "ok" ]; then
-    echo "  Health check: OK"
+health=$(python -c "import urllib.request; print(urllib.request.urlopen('http://localhost:${PORT}/api/ping').read().decode())" 2>/dev/null || echo "FAIL")
+if [ "$health" = "ok" ]; then
+    echo "  ✓ Health check OK"
 else
-    echo "  Health check: FAILED (got: $HEALTH)"
-    kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null
+    echo "  ✗ Health check FAILED (got: $health)"
+    kill $UI_PID 2>/dev/null; wait $UI_PID 2>/dev/null || true
+    deactivate; rm -rf "$VENV_DIR" "$HAMILTON_BASE_DIR"
     exit 1
 fi
 
 # Frontend check
-echo "Checking frontend serves..."
 python -c "
 import urllib.request
 resp = urllib.request.urlopen('http://localhost:${PORT}/')
 html = resp.read().decode()
 assert '<div id=\"root\"' in html or '<html' in html.lower(), 'No HTML served'
-print('  Frontend: OK')
 "
+echo "  ✓ Frontend serves HTML"
 
-# Cleanup
-kill $SERVER_PID 2>/dev/null; wait $SERVER_PID 2>/dev/null || true
+kill $UI_PID 2>/dev/null; wait $UI_PID 2>/dev/null || true
 deactivate
 rm -rf "$VENV_DIR" "$HAMILTON_BASE_DIR"
 
-echo "=== apache-hamilton-ui ${VERSION}: PASSED ==="
+echo ""
+echo "=== ${PACKAGE} ${VERSION}-RC${RC}: ALL CHECKS PASSED ==="


### PR DESCRIPTION
## Changes

Updates `scripts/verify-sub-packages/verify_*.sh` to be fully self-contained release validation scripts. Each one now performs all 6 verification steps autonomously:

1. Downloads artifacts from SVN (or accepts a local artifacts dir)
2. Verifies GPG signatures
3. Verifies SHA512 checksums
4. Runs Apache RAT license check (using repo's `.rat-excludes`)
5. Builds from source tarball with `flit build --no-use-vcs`
6. Installs wheel in fresh `uv venv` and runs functional tests

Also adds `scripts/verification-sub-packages.sh` orchestrator.

## Usage

Reviewer validates a single package:
```bash
scripts/verify-sub-packages/verify_sdk.sh 0.9.0 0
scripts/verify-sub-packages/verify_ui.sh 0.0.18 0
scripts/verify-sub-packages/verify_lsp.sh 0.2.0 0
scripts/verify-sub-packages/verify_contrib.sh 0.0.9 0
```

Or with pre-downloaded artifacts:
```bash
scripts/verify-sub-packages/verify_sdk.sh 0.9.0 0 ./path/to/artifacts/
```

## How I tested

Ran all 4 scripts against the dry-run RC0 artifacts built from a fresh checkout:
```
=== apache-hamilton-sdk 0.9.0-RC0: ALL CHECKS PASSED ===
=== apache-hamilton-ui 0.0.18-RC0: ALL CHECKS PASSED ===
=== apache-hamilton-lsp 0.2.0-RC0: ALL CHECKS PASSED ===
=== apache-hamilton-contrib 0.0.9-RC0: ALL CHECKS PASSED ===
```