### PR TITLE
Update/robustify the release scripts for subpackages (apache-hamilton-*)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ default_stages: [pre-commit, pre-merge-commit]
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.12
+    rev: v0.15.14
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -43,6 +43,7 @@ repos:
       - id: requirements-txt-fixer
       # valid python file
       - id: check-ast
+      - id: check-toml
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6
     hooks:

--- a/contrib/pyproject.toml
+++ b/contrib/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-hamilton-contrib"
-version = "0.0.8"
+version = "0.0.8"  # Keep in sync with contrib/hamilton/contrib/version.py until this becomes dynamic
 description = "Apache Hamilton's user contributed shared dataflow library."
 readme = "README.md"
 requires-python = ">=3.10, <4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,6 +284,11 @@ exclude = ["*tests*"]
 [tool.setuptools.package-data]
 hamilton = ["*.json", "*.md", "*.txt"]
 
+[tool.uv.sources]
+apache-hamilton-lsp = { path = "dev_tools/language_server", editable = true }
+apache-hamilton-sdk = { path = "ui/sdk", editable = true }
+apache-hamilton-ui = { path = "ui/backend", editable = true }
+
 [tool.flit.module]
 name = "hamilton"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ experiments = [
   "fastui",
   "uvicorn",
 ]
-lsp = ["sf-hamilton-lsp"]  # TODO: switch to apache-hamilton-lsp once stable version is published
+lsp = ["apache-hamilton-lsp"]
 openlineage = ["openlineage-python"]
 pandera = ["pandera"]
 pydantic = ["pydantic>=2.0"]
@@ -77,12 +77,12 @@ pyspark = [
 ]
 ray = ["ray>=2.0.0; python_version < '3.14'", "pyarrow"]
 rich = ["rich"]
-sdk = ["sf-hamilton-sdk"]  # TODO: switch to apache-hamilton-sdk once stable version is published
+sdk = ["apache-hamilton-sdk"]
 slack = ["slack-sdk"]
 
 mcp = ["fastmcp>=3.0.0,<4"]
 tqdm = ["tqdm"]
-ui = ["sf-hamilton-ui"]  # TODO: switch to apache-hamilton-ui once stable version is published
+ui = ["apache-hamilton-ui"]
 
 # vaex -- on >=py3.11 only core part available https://github.com/vaexio/vaex/pull/2331#issuecomment-2437198176
 vaex = [

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -136,7 +136,7 @@ To build and sign artifacts without uploading to SVN or creating a git tag:
 
 ```bash
 uv run python scripts/apache_release_helper.py \
-    --package ${PACKAGE_KEY} ${VERSION} ${RC} ${APACHE_ID} --dry-run
+    --package ${PACKAGE_KEY} ${VERSION} ${RC} ${APACHE_ID} --no-sign
 ```
 
 ### After the Vote Passes
@@ -162,7 +162,7 @@ export TAG="${PACKAGE}-v${VERSION}-incubating-RC${RC}"
 
 ```bash
 # Dry run first to verify
-scripts/promote_rc.sh --dry-run ${PACKAGE} ${VERSION} ${RC}
+scripts/promote_rc.sh --no-sign ${PACKAGE} ${VERSION} ${RC}
 
 # Then promote for real
 scripts/promote_rc.sh ${PACKAGE} ${VERSION} ${RC}

--- a/scripts/apache_release_helper.py
+++ b/scripts/apache_release_helper.py
@@ -15,6 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# /// script
+# dependencies = [
+#   "build",
+#   "flit",
+#   "twine",
+# ]
+# ///
+
 import argparse
 import glob
 import hashlib

--- a/scripts/apache_release_helper.py
+++ b/scripts/apache_release_helper.py
@@ -320,6 +320,34 @@ def create_release_artifacts(package_config: dict, version) -> list[str]:
         if os.path.exists("dist"):
             shutil.rmtree("dist")
 
+        # For the UI package, build the frontend before packaging.
+        if package_name == "apache-hamilton-ui":
+            print("Building UI frontend (npm install + npm run build)...")
+            frontend_dir = os.path.join(original_dir, "ui", "frontend")
+            build_target = os.path.join("hamilton_ui", "build")
+            try:
+                subprocess.run(
+                    ["npm", "install", "--prefix", frontend_dir],
+                    check=True,
+                )
+                subprocess.run(
+                    ["npm", "run", "build", "--prefix", frontend_dir],
+                    check=True,
+                )
+                # Copy built assets to hamilton_ui/build/
+                if os.path.exists(build_target):
+                    shutil.rmtree(build_target)
+                # Vite outputs to frontend/dist/, CRA outputs to frontend/build/
+                frontend_build = os.path.join(frontend_dir, "dist")
+                if not os.path.exists(frontend_build):
+                    frontend_build = os.path.join(frontend_dir, "build")
+                shutil.copytree(frontend_build, build_target)
+                print(f"Frontend built and copied to {build_target}")
+            except (subprocess.CalledProcessError, FileNotFoundError) as e:
+                print(f"Error building frontend: {e}")
+                print("Ensure Node.js and npm are installed.")
+                return None
+
         # Use flit build to create the source distribution.
         try:
             subprocess.run(

--- a/scripts/apache_release_helper.py
+++ b/scripts/apache_release_helper.py
@@ -202,6 +202,16 @@ def sign_artifacts(archive_name: str) -> list[str] | None:
         print(f"Created GPG signature: {archive_name}.asc")
     except subprocess.CalledProcessError as e:
         print(f"Error signing tarball: {e}")
+        print(
+            "Tip: if you don't have a GPG key configured, re-run with --no-sign (and optionally\n"
+            "--no-upload) to skip signing and SVN upload (useful for local testing).\n"
+            "To set up a GPG key for real releases:\n"
+            "  1. gpg --gen-key\n"
+            "  2. gpg --list-secret-keys   # note your KEYID\n"
+            "  3. gpg --armor --export <KEYID> >> KEYS\n"
+            "  4. Set default-key <KEYID> in ~/.gnupg/gpg.conf if you have multiple keys.\n"
+            "  5. Upload your key fingerprint to id.apache.org before voting."
+        )
         return None
 
     # Generate SHA512 checksum.
@@ -311,7 +321,7 @@ def _modify_tarball_for_apache_release(
             tar.add(extracted_dir, arcname=os.path.basename(extracted_dir))
 
 
-def create_release_artifacts(package_config: dict, version) -> list[str]:
+def create_release_artifacts(package_config: dict, version, no_sign: bool = False) -> list[str]:
     """Creates the source tarball, GPG signature, and checksums using flit build."""
     package_name = package_config["name"]
     working_dir = package_config["working_dir"]
@@ -397,9 +407,13 @@ def create_release_artifacts(package_config: dict, version) -> list[str]:
         os.remove(tarball_file)
         archive_name = new_tar_ball
         print(f"Found source tarball: {archive_name}")
-        new_tar_ball_signed = sign_artifacts(archive_name)
-        if new_tar_ball_signed is None:
-            raise ValueError("Could not sign the main release artifacts.")
+        if no_sign:
+            print("Skipping GPG signing (--no-sign).")
+            new_tar_ball_signed = []
+        else:
+            new_tar_ball_signed = sign_artifacts(archive_name)
+            if new_tar_ball_signed is None:
+                raise ValueError("Could not sign the main release artifacts.")
 
         # Wheel keeps its original PEP 427 filename (no -incubating suffix)
         expected_wheel = f"dist/{package_file_name}-{version.lower()}-py3-none-any.whl"
@@ -414,7 +428,10 @@ def create_release_artifacts(package_config: dict, version) -> list[str]:
         if not verify_wheel_with_twine(wheel_file):
             raise ValueError("Wheel failed twine validation.")
 
-        wheel_signed_files = sign_artifacts(wheel_file)
+        if no_sign:
+            wheel_signed_files = []
+        else:
+            wheel_signed_files = sign_artifacts(wheel_file)
 
         files_to_upload = [new_tar_ball, *new_tar_ball_signed, wheel_file, *wheel_signed_files]
         return files_to_upload
@@ -557,12 +574,17 @@ def main():
 
     Note: if you have multiple gpg keys, specify the default in ~/.gnupg/gpg.conf add a line with `default-key <KEYID>`.
 
+    Use --no-sign (-ns) to skip GPG signing (e.g., when a key is not available locally).
+    This implicitly sets --no-upload, since unsigned artifacts must never be published.
+    Use --no-upload (-nu) alone to build and sign without publishing (e.g., to rehearse signing).
+
     Examples:
         python apache_release_helper.py --package hamilton 1.89.0 0 your_apache_id
         python apache_release_helper.py --package sdk 0.8.0 0 your_apache_id
         python apache_release_helper.py --package lsp 0.1.0 0 your_apache_id
         python apache_release_helper.py --package contrib 0.0.8 0 your_apache_id
         python apache_release_helper.py --package ui 0.0.17 0 your_apache_id
+        python apache_release_helper.py -ns --package ui 0.0.18 0
     """
     parser = argparse.ArgumentParser(
         description="Automates parts of the Apache release process for Hamilton packages."
@@ -575,18 +597,36 @@ def main():
     )
     parser.add_argument("version", help="The new release version (e.g., '1.0.0').")
     parser.add_argument("rc_num", help="The release candidate number (e.g., '0' for RC0).")
-    parser.add_argument("apache_id", help="Your apache user ID.")
     parser.add_argument(
-        "--dry-run",
+        "apache_id",
+        nargs="?",
+        default=None,
+        help="Your Apache user ID. Required unless --no-upload is set.",
+    )
+    parser.add_argument(
+        "-ns",
+        "--no-sign",
         action="store_true",
-        help="Build and sign artifacts but skip git tagging and SVN upload.",
+        help="Skip GPG signing. Unsigned artifacts cannot be used for an official release vote.",
+    )
+    parser.add_argument(
+        "-nu",
+        "--no-upload",
+        action="store_true",
+        help="Skip git tagging and SVN upload. Useful for validating the build locally.",
     )
     args = parser.parse_args()
+
+    if args.no_sign:
+        args.no_upload = True  # never upload unsigned artifacts
 
     package_key = args.package
     version = args.version
     rc_num = args.rc_num
     apache_id = args.apache_id
+
+    if not args.no_upload and not apache_id:
+        parser.error("apache_id is required unless --no-upload (or --no-sign) is set.")
 
     # Get package configuration
     package_config = PACKAGE_CONFIGS[package_key]
@@ -607,8 +647,8 @@ def main():
 
     # Create git tag (from repo root)
     tag_name = f"{package_name}-v{version}-incubating-RC{rc_num}"
-    if args.dry_run:
-        print(f"\n[dry-run] Skipping git tag creation: {tag_name}")
+    if args.no_upload:
+        print(f"\n[--no-upload] Skipping git tag creation: {tag_name}")
     else:
         print(f"\nChecking for git tag '{tag_name}'...")
         try:
@@ -635,19 +675,19 @@ def main():
     print(f"\n{'=' * 80}")
     print("  Building Release Artifacts")
     print(f"{'=' * 80}\n")
-    files_to_upload = create_release_artifacts(package_config, version)
+    files_to_upload = create_release_artifacts(package_config, version, no_sign=args.no_sign)
     if not files_to_upload:
         sys.exit(1)
 
-    if args.dry_run:
-        # Dry run: skip SVN upload, show summary
+    if args.no_upload:
         print(f"\n{'=' * 80}")
-        print("  [dry-run] Skipping SVN upload")
+        print("  [--no-upload] Skipping SVN upload")
         print(f"{'=' * 80}\n")
         print("Artifacts built successfully:")
         for f in files_to_upload:
             print(f"  {f}")
-        print("\nTo do a real release, re-run without --dry-run.")
+        if args.no_sign:
+            print("\nNote: artifacts are unsigned and cannot be used for an official release vote.")
     else:
         # Upload artifacts
         print(f"\n{'=' * 80}")

--- a/scripts/verify-sub-packages.md
+++ b/scripts/verify-sub-packages.md
@@ -95,7 +95,7 @@ cp -r dist/ ../backend/hamilton_ui/build/
 
 # Now build the wheel
 cd ../backend
-flit build --no-use-vcs
+uvx flit build --no-use-vcs
 ```
 
 The release script (`scripts/apache_release_helper.py --package ui`) handles

--- a/scripts/verify-sub-packages.md
+++ b/scripts/verify-sub-packages.md
@@ -79,6 +79,28 @@ See `examples/hamilton_ui/` — the same example above.
 
 ## apache-hamilton-ui
 
+### Building from source (requires Node.js + npm)
+
+The UI package includes compiled frontend assets. When building from source,
+you must build the frontend first:
+
+```bash
+cd ui/frontend
+npm install
+npm run build
+
+# Copy built assets to the backend package
+rm -rf ../backend/hamilton_ui/build
+cp -r dist/ ../backend/hamilton_ui/build/
+
+# Now build the wheel
+cd ../backend
+flit build --no-use-vcs
+```
+
+The release script (`scripts/apache_release_helper.py --package ui`) handles
+this automatically.
+
 ### Install and verify
 
 ```bash

--- a/scripts/verify-sub-packages/verify_contrib.sh
+++ b/scripts/verify-sub-packages/verify_contrib.sh
@@ -116,7 +116,7 @@ build_dir="/tmp/build-contrib-$$"
 mkdir -p "$build_dir"
 tar xzf "$ARTIFACTS_DIR/$SRC_TAR" -C "$build_dir"
 src_dir=$(ls -d ${build_dir}/*/ | head -1)
-if (cd "$src_dir" && flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
+if (cd "$src_dir" && uvx flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
     echo "  ✓ Built from source successfully"
 else
     echo "  ✗ Build from source failed"

--- a/scripts/verify-sub-packages/verify_contrib.sh
+++ b/scripts/verify-sub-packages/verify_contrib.sh
@@ -131,6 +131,7 @@ echo "--- Functional verification ---"
 VENV_DIR="/tmp/verify-contrib-func-$$"
 uv venv "$VENV_DIR" --python 3.12 -q
 source "$VENV_DIR/bin/activate"
+cd /tmp  # prevent '' in sys.path from resolving local hamilton checkout
 
 uv pip install -q "$ARTIFACTS_DIR/$WHEEL" apache-hamilton
 

--- a/scripts/verify-sub-packages/verify_lsp.sh
+++ b/scripts/verify-sub-packages/verify_lsp.sh
@@ -131,6 +131,7 @@ echo "--- Functional verification ---"
 VENV_DIR="/tmp/verify-lsp-func-$$"
 uv venv "$VENV_DIR" --python 3.12 -q
 source "$VENV_DIR/bin/activate"
+cd /tmp  # prevent '' in sys.path from resolving local hamilton checkout
 
 uv pip install -q "$ARTIFACTS_DIR/$WHEEL" "apache-hamilton[visualization]"
 

--- a/scripts/verify-sub-packages/verify_lsp.sh
+++ b/scripts/verify-sub-packages/verify_lsp.sh
@@ -116,7 +116,7 @@ build_dir="/tmp/build-lsp-$$"
 mkdir -p "$build_dir"
 tar xzf "$ARTIFACTS_DIR/$SRC_TAR" -C "$build_dir"
 src_dir=$(ls -d ${build_dir}/*/ | head -1)
-if (cd "$src_dir" && flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
+if (cd "$src_dir" && uvx flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
     echo "  ✓ Built from source successfully"
 else
     echo "  ✗ Build from source failed"

--- a/scripts/verify-sub-packages/verify_sdk.sh
+++ b/scripts/verify-sub-packages/verify_sdk.sh
@@ -116,7 +116,7 @@ build_dir="/tmp/build-sdk-$$"
 mkdir -p "$build_dir"
 tar xzf "$ARTIFACTS_DIR/$SRC_TAR" -C "$build_dir"
 src_dir=$(ls -d ${build_dir}/*/ | head -1)
-if (cd "$src_dir" && flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
+if (cd "$src_dir" && uvx flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
     echo "  ✓ Built from source successfully"
 else
     echo "  ✗ Build from source failed"

--- a/scripts/verify-sub-packages/verify_sdk.sh
+++ b/scripts/verify-sub-packages/verify_sdk.sh
@@ -131,6 +131,7 @@ echo "--- Functional verification ---"
 VENV_DIR="/tmp/verify-sdk-func-$$"
 uv venv "$VENV_DIR" --python 3.12 -q
 source "$VENV_DIR/bin/activate"
+cd /tmp  # prevent '' in sys.path from resolving local hamilton checkout
 
 uv pip install -q "$ARTIFACTS_DIR/$WHEEL" apache-hamilton
 

--- a/scripts/verify-sub-packages/verify_ui.sh
+++ b/scripts/verify-sub-packages/verify_ui.sh
@@ -121,7 +121,7 @@ src_dir=$(ls -d ${build_dir}/*/ | head -1)
 # The release script builds the frontend (npm run build) before flit build.
 # Here we verify the backend builds correctly; the wheel from SVN includes
 # the pre-compiled frontend and is what's tested in step 6.
-if (cd "$src_dir" && flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
+if (cd "$src_dir" && uvx flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
     echo "  ✓ Built from source successfully (backend only, frontend is pre-compiled in wheel)"
 else
     echo "  ✗ Build from source failed"

--- a/scripts/verify-sub-packages/verify_ui.sh
+++ b/scripts/verify-sub-packages/verify_ui.sh
@@ -116,8 +116,13 @@ build_dir="/tmp/build-ui-$$"
 mkdir -p "$build_dir"
 tar xzf "$ARTIFACTS_DIR/$SRC_TAR" -C "$build_dir"
 src_dir=$(ls -d ${build_dir}/*/ | head -1)
+
+# Note: The UI source tarball does not include compiled frontend assets.
+# The release script builds the frontend (npm run build) before flit build.
+# Here we verify the backend builds correctly; the wheel from SVN includes
+# the pre-compiled frontend and is what's tested in step 6.
 if (cd "$src_dir" && flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
-    echo "  ✓ Built from source successfully"
+    echo "  ✓ Built from source successfully (backend only, frontend is pre-compiled in wheel)"
 else
     echo "  ✗ Build from source failed"
     rm -rf "$build_dir"

--- a/scripts/verify-sub-packages/verify_ui.sh
+++ b/scripts/verify-sub-packages/verify_ui.sh
@@ -139,6 +139,7 @@ PORT=8241
 
 uv venv "$VENV_DIR" --python 3.12 -q
 source "$VENV_DIR/bin/activate"
+cd /tmp  # prevent '' in sys.path from resolving local hamilton checkout
 
 uv pip install -q "$ARTIFACTS_DIR/$WHEEL" apache-hamilton packaging
 

--- a/scripts/verify-sub-packages/verify_ui.sh
+++ b/scripts/verify-sub-packages/verify_ui.sh
@@ -122,7 +122,7 @@ src_dir=$(ls -d ${build_dir}/*/ | head -1)
 # Here we verify the backend builds correctly; the wheel from SVN includes
 # the pre-compiled frontend and is what's tested in step 6.
 if (cd "$src_dir" && uvx flit build --no-use-vcs) 2>&1 | grep -q "Built wheel"; then
-    echo "  ✓ Built from source successfully (backend only, frontend is pre-compiled in wheel)"
+    echo "  ✓ Built from source successfully (backend only)"
 else
     echo "  ✗ Build from source failed"
     rm -rf "$build_dir"
@@ -172,10 +172,23 @@ fi
 
 # Frontend check
 python -c "
-import urllib.request
-resp = urllib.request.urlopen('http://localhost:${PORT}/')
-html = resp.read().decode()
-assert '<div id=\"root\"' in html or '<html' in html.lower(), 'No HTML served'
+import importlib.util, sys, urllib.request, urllib.error
+from pathlib import Path
+
+spec = importlib.util.find_spec('hamilton_ui')
+pkg_dir = Path(spec.origin).parent
+index_html = pkg_dir / 'build' / 'index.html'
+if not index_html.exists():
+    print(f'  ✗ Frontend not bundled in wheel (missing {index_html})', file=sys.stderr)
+    sys.exit(1)
+
+try:
+    resp = urllib.request.urlopen('http://localhost:${PORT}/')
+    html = resp.read().decode()
+    assert '<div id=\"root\"' in html or '<html' in html.lower(), 'No HTML served'
+except urllib.error.HTTPError as e:
+    print(f'  ✗ GET / returned HTTP {e.code} — server error despite bundled frontend', file=sys.stderr)
+    sys.exit(1)
 "
 echo "  ✓ Frontend serves HTML"
 

--- a/ui/backend/README.md
+++ b/ui/backend/README.md
@@ -1,0 +1,85 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Apache Hamilton UI: Tracking Server
+
+> **Disclaimer**
+>
+> Apache Hamilton is an effort undergoing incubation at the Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+>
+> Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects.
+>
+> While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
+
+`apache-hamilton-ui` is the tracking server and web application for visualizing, monitoring, and
+debugging Apache Hamilton dataflow DAGs.
+
+## Features
+
+- Visualize Hamilton DAGs and their execution history
+- Track inputs, outputs, and runtime metadata for each DAG run
+- Compare runs across versions and configurations
+- Self-hosted: run locally or deploy on your own infrastructure
+
+## Getting Started
+
+The easiest way to run the UI is via Docker:
+
+```bash
+git clone https://github.com/apache/hamilton
+cd hamilton/ui
+docker-compose up
+```
+
+Then open [http://localhost:8242](http://localhost:8242) in your browser.
+
+For full documentation, visit [hamilton.apache.org](https://hamilton.apache.org/) and see the
+**Apache Hamilton UI** section.
+
+## Connecting Hamilton to the UI
+
+Install the tracking SDK alongside your Hamilton project:
+
+```bash
+pip install "apache-hamilton[sdk]"
+```
+
+Then add a `HamiltonTracker` adapter to your driver:
+
+```python
+from hamilton_sdk import adapters
+from hamilton import driver
+
+tracker = adapters.HamiltonTracker(
+    project_id=PROJECT_ID,
+    username=YOUR_EMAIL,
+    dag_name="my_dag",
+)
+dr = (
+    driver.Builder()
+    .with_config(your_config)
+    .with_modules(*your_modules)
+    .with_adapters(tracker)
+    .build()
+)
+```
+
+## License
+
+Apache 2.0. See the main repository [LICENSE](../../LICENSE) for details.

--- a/ui/backend/pyproject.toml
+++ b/ui/backend/pyproject.toml
@@ -23,6 +23,7 @@ build-backend = "flit_core.buildapi"
 name = "apache-hamilton-ui"
 version = "0.0.17"
 description = "Apache Hamilton UI tracking server for dataflow visualization and monitoring."
+readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.10.1, <4"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "DISCLAIMER"]

--- a/ui/backend/server/server/urls.py
+++ b/ui/backend/server/server/urls.py
@@ -34,7 +34,6 @@ Including another URLconf
 from django.conf import settings
 from django.contrib import admin
 from django.urls import path, re_path
-from django.views.generic import TemplateView
 from django.views.static import serve
 
 from . import api, default_views
@@ -83,8 +82,13 @@ if settings.HAMILTON_ENV == "mini":
             )
         )
 
-    # Catch-all route for SPA routing - this MUST be last
-    urlpatterns.append(re_path(".*", TemplateView.as_view(template_name="index.html")))
+    # Catch-all route for SPA routing - this MUST be last.
+    # Use serve() rather than TemplateView so the file is returned as raw bytes
+    # (avoids TemplateSyntaxError on compiled JS/HTML) and so a missing index.html
+    # produces a 404 instead of a 500.
+    urlpatterns.append(
+        re_path(".*", serve, {"document_root": str(build_dir), "path": "index.html"})
+    )
 else:
     urlpatterns = [
         path("api/", api.api.urls),

--- a/ui/frontend/package-lock.json
+++ b/ui/frontend/package-lock.json
@@ -3396,9 +3396,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3953,9 +3953,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/sdk/.pre-commit-config.yaml
+++ b/ui/sdk/.pre-commit-config.yaml
@@ -24,12 +24,12 @@
 repos:
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.12
+    rev: v0.15.14
     hooks:
         - id: ruff-check
           args: [ --fix , --exit-non-zero-on-fix ]
 -   repo: https://github.com/ambv/black
-    rev: 26.3.1
+    rev: 26.5.1
     hooks:
     - id: black
       args: [--line-length=100]
@@ -43,3 +43,4 @@ repos:
     -   id: requirements-txt-fixer
     # valid python file
     -   id: check-ast
+    -   id: check-toml


### PR DESCRIPTION
This PR contains QoL improvements and fixes to various issues encountered while verifying the `apache-hamilton-{sdk,ui,lsp,contrib}` packages in the context of https://lists.apache.org/thread/d4fzmqq4jbsx5m3krdp1qbr0wh9j131s and related threads.

Includes #1612

## Changes
### UI Package (`apache-hamilton-ui`)
- **Added `README.md`** for the `ui/backend` package, fixing `long_description`/`long_description_content_type` warnings during `flit build`
- **Frontend build step**: the release script now runs `npm run build` and copies compiled frontend assets into `hamilton_ui/build/` before building the wheel, ensuring the UI package includes its frontend (from #1612)
- **npm audit fix**: resolved one moderate severity vulnerability in frontend dependencies

### Release Helper (`scripts/apache_release_helper.py`)
- **`--no-sign` / `-ns`**: skips GPG signing; implicitly also skips upload since unsigned artifacts must never be published
- **`--no-upload` / `-nu`**: skips git tagging and SVN upload while still signing; useful for rehearsing the full signing step without publishing
- **`apache_id` is no longer required** when `--no-upload` (or `--no-sign`) is set
- **`uv` script dependencies declared** in the PEP 723 inline metadata block so the script can be run with `uv run`

### Verification Scripts (`scripts/verify-sub-packages/`)
- **`cd /tmp` before functional checks** in all four verify scripts (`verify_contrib.sh`, `verify_sdk.sh`, `verify_lsp.sh`, `verify_ui.sh`): prevents Python's implicit `''` (cwd) `sys.path` entry from resolving the local checkout instead of the venv-installed packages when the script is run from the repo root
- **More informative error in `verify_ui.sh`**: improved diagnostics when the UI health-check endpoint is unreachable
- **`uvx flit`** used in place of a separately installed `flit` across all verify scripts
- **TOML verification pre-commit hook** added to `ui/sdk/.pre-commit-config.yaml`

## How I tested this
After introducing these changes I could successfully run the verification **shell** scripts for all distributions as well as `uv run scripts/apache_release_helper.py --package {pkg} {ver} 0 -ns`

## Notes
I had include the version bump commit so that `apache_release_helper.py` runs correctly (with the new versions). We might want to consider making the version mismatch non-fatal when building packages with no intention to upload them.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
