### PR TITLE
Fix async client swallowing backend errors during flush

### DIFF
--- a/ui/sdk/src/hamilton_sdk/api/clients.py
+++ b/ui/sdk/src/hamilton_sdk/api/clients.py
@@ -609,9 +609,9 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
                     try:
                         response.raise_for_status()
                         logger.debug(f"Updated tasks for DAG run {dag_run_id}")
-                    except HTTPError:
+                    except aiohttp.ClientResponseError:
                         logger.exception(f"Failed to update tasks for DAG run {dag_run_id}")
-                        # zraise
+                        raise
 
     async def worker(self):
         """Worker thread to process the queue"""

--- a/ui/sdk/tests/test_clients.py
+++ b/ui/sdk/tests/test_clients.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+from hamilton_sdk.api.clients import BasicAsynchronousHamiltonClient
+
+
+def _make_client():
+    return BasicAsynchronousHamiltonClient(
+        api_key="test-key",
+        username="test-user",
+        h_api_url="http://localhost:8241",
+    )
+
+
+def _mock_session_with_status(status: int):
+    """Build a mocked aiohttp.ClientSession() chain whose response
+    .raise_for_status() raises ClientResponseError if status >= 400."""
+    response = MagicMock()
+    if status >= 400:
+        response.raise_for_status.side_effect = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=status,
+            message=f"HTTP {status}",
+        )
+    else:
+        response.raise_for_status.return_value = None
+
+    put_cm = MagicMock()
+    put_cm.__aenter__ = AsyncMock(return_value=response)
+    put_cm.__aexit__ = AsyncMock(return_value=False)
+
+    session = MagicMock()
+    session.put.return_value = put_cm
+
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    return session_cm
+
+
+def test_async_flush_re_raises_on_backend_error():
+    """Regression: flush() used to catch requests.HTTPError (the wrong class
+    for aiohttp) and swallowed errors via a `# zraise` tombstone. A non-2xx
+    response from the backend must now propagate."""
+
+    async def run():
+        client = _make_client()
+        batch = [{"dag_run_id": 1, "attributes": [], "task_updates": []}]
+        with patch("aiohttp.ClientSession", return_value=_mock_session_with_status(500)):
+            with pytest.raises(aiohttp.ClientResponseError):
+                await client.flush(batch)
+
+    asyncio.run(run())
+
+
+def test_async_flush_succeeds_on_2xx():
+    async def run():
+        client = _make_client()
+        batch = [{"dag_run_id": 1, "attributes": [], "task_updates": []}]
+        with patch("aiohttp.ClientSession", return_value=_mock_session_with_status(200)):
+            await client.flush(batch)
+
+    asyncio.run(run())


### PR DESCRIPTION
## Changes
 - Async client flush catches HTTPError but the call uses aiohttp, so the except never matched. Backend errors propagated up unhandled and killed the worker task.
 - Add a raise so failures actually surface.
 - Switch to except aiohttp.ClientResponseError, matching every other async method in this file.

## How I tested this
 - UT
## Notes

## Checklist

- [X] PR has an informative and human-readable title (this will be pulled into the release notes)
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future TODOs are captured in comments
- [X] Project documentation has been updated if adding/changing functionality.
