### PR TITLE
fix(caching): include shape/dtype/schema in fingerprint hashing

### DIFF
--- a/hamilton/caching/fingerprinting.py
+++ b/hamilton/caching/fingerprinting.py
@@ -243,11 +243,33 @@ def hash_set(obj, *args, depth: int = 0, **kwargs) -> str:
     return _compact_hash(hash_object.digest())
 
 
+def _pandas_schema_repr(obj) -> str:
+    """Stringify the schema-defining metadata of a pandas DataFrame/Series/Index.
+
+    Used to ensure objects with the same row values but different column
+    names or dtypes hash differently.
+    """
+    import pandas as pd
+
+    if isinstance(obj, pd.DataFrame):
+        return "DataFrame" + repr(
+            [(str(c), str(t)) for c, t in zip(obj.columns, obj.dtypes)]
+        )
+    if isinstance(obj, pd.Series):
+        return f"Series(name={obj.name!r}, dtype={obj.dtype})"
+    return f"Index(name={getattr(obj, 'name', None)!r}, dtype={obj.dtype})"
+
+
 @hash_value.register(h_databackends.AbstractPandasDataFrame)
 @hash_value.register(h_databackends.AbstractPandasColumn)
 def hash_pandas_obj(obj, *args, depth: int = 0, **kwargs) -> str:
     """Convert a pandas dataframe, series, or index to
     a dictionary of {index: row_hash} then hash it.
+
+    The schema (column names + dtypes for a DataFrame; name + dtype for a
+    Series or Index) is included alongside the row-value hashes so that
+    objects with identical row values but different schemas produce
+    different fingerprints.
 
     Given the hashing for mappings, the physical ordering or rows doesn't matter.
     For example, if the index is a date, the hash will represent the {date: row_hash},
@@ -256,16 +278,22 @@ def hash_pandas_obj(obj, *args, depth: int = 0, **kwargs) -> str:
     from pandas.util import hash_pandas_object
 
     hash_per_row = hash_pandas_object(obj)
-    return hash_mapping(hash_per_row.to_dict(), ignore_order=False, depth=depth + 1)
+    rows_hash = hash_mapping(hash_per_row.to_dict(), ignore_order=False, depth=depth + 1)
+    return hash_sequence([_pandas_schema_repr(obj), rows_hash], depth=depth + 1)
 
 
 @hash_value.register(h_databackends.AbstractPolarsDataFrame)
 def hash_polars_dataframe(obj, *args, depth: int = 0, **kwargs) -> str:
-    """Convert a polars dataframe, series, or index to
-    a list of hashes then hash it.
+    """Convert a polars dataframe to a list of row hashes then hash it.
+
+    The schema (column names + dtypes) is included alongside the row-value
+    hashes so that DataFrames with identical row values but different
+    schemas (e.g. a renamed column, or a column whose dtype changed)
+    produce different fingerprints.
     """
     hash_per_row = obj.hash_rows()
-    return hash_sequence(hash_per_row.to_list(), depth=depth + 1)
+    schema_repr = str(obj.schema)
+    return hash_sequence([schema_repr, *hash_per_row.to_list()], depth=depth + 1)
 
 
 @hash_value.register(h_databackends.AbstractPolarsColumn)
@@ -277,11 +305,17 @@ def hash_polars_column(obj, *args, depth: int = 0, **kwargs) -> str:
 
 @hash_value.register(h_databackends.AbstractNumpyArray)
 def hash_numpy_array(obj, *args, depth: int = 0, **kwargs) -> str:
-    """Get the bytes representation of the array raw data and hash it.
+    """Hash a numpy array, including its shape and dtype alongside its bytes.
 
-    Might not be ideal because different higher-level numpy objects could have
-    the same underlying array representation (e.g., masked arrays).
-    Unsure, but it's an area to investigate.
+    The previous implementation hashed ``obj.tobytes()`` alone, which
+    discards shape and dtype. Two arrays with the same underlying byte
+    buffer but different shapes (e.g. ``(6,)`` vs ``(2, 3)`` vs ``(3, 2)``)
+    or different dtypes (e.g. an int32 array vs an int16 array whose bytes
+    happen to align) would collide. Including ``shape`` and ``dtype`` in
+    the hash prevents this.
     """
-    # use the same depth because we're simply dispatching to another implementation
-    return hash_bytes(obj.tobytes(), depth=depth)
+    hash_object = hashlib.md5()
+    hash_object.update(repr(obj.shape).encode())
+    hash_object.update(str(obj.dtype).encode())
+    hash_object.update(obj.tobytes())
+    return _compact_hash(hash_object.digest())

--- a/tests/caching/test_fingerprinting.py
+++ b/tests/caching/test_fingerprinting.py
@@ -203,13 +203,93 @@ def test_hash_set():
 def test_hash_pandas():
     """pandas has a specialized hash function"""
     obj = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
-    expected_hash = "LSHACWyG83JBIggxO9LGrerW3WZEy4nUOmIQoA=="
+    expected_hash = "MWVRUkabse6nLJsK06OFiUhmhjAxJVSNjW0K4g=="
     fingerprint = fingerprinting.hash_pandas_obj(obj)
     assert fingerprint == expected_hash
 
 
 def test_hash_numpy():
     array = np.array([[0, 1], [2, 3]])
-    expected_hash = "ZwjDgY0zQOxO9KPHlYecog=="
+    expected_hash = "y11RlC0yMA5eIroRCt0I2w=="
     fingerprint = fingerprinting.hash_value(array)
     assert fingerprint == expected_hash
+
+
+def test_hash_numpy_distinguishes_shape():
+    """A flat 1D array and a 2D reshape of the same bytes must not collide.
+
+    Prior to the shape-aware fix, ``hash_numpy_array`` hashed only
+    ``obj.tobytes()``, so arrays with different shapes but the same
+    underlying byte buffer produced identical hashes -- causing the
+    cache to return the wrong result for semantically distinct inputs.
+    """
+    flat = np.array([1, 2, 3, 4, 5, 6], dtype=np.int64)
+    wide = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int64)
+    tall = np.array([[1, 2], [3, 4], [5, 6]], dtype=np.int64)
+    # Precondition: the underlying byte buffers are identical.
+    assert flat.tobytes() == wide.tobytes() == tall.tobytes()
+    # Postcondition: hashes are pairwise distinct.
+    hashes = {fingerprinting.hash_value(x) for x in (flat, wide, tall)}
+    assert len(hashes) == 3
+
+
+def test_hash_numpy_distinguishes_dtype():
+    """Arrays whose bytes happen to align across dtypes must not collide."""
+    as_int32 = np.array([1, 2, 3], dtype=np.int32)
+    as_int16 = np.array([1, 0, 2, 0, 3, 0], dtype=np.int16)
+    assert as_int32.tobytes() == as_int16.tobytes()
+    assert fingerprinting.hash_value(as_int32) != fingerprinting.hash_value(as_int16)
+
+
+def test_hash_pandas_distinguishes_column_names():
+    """Two DataFrames with identical row values but different column
+    names must not collide -- e.g. ``customer_revenue`` and
+    ``product_cost`` with the same numeric column must hash distinctly.
+    """
+    revenue = pd.DataFrame({"customer_revenue": [100, 200, 300]})
+    cost = pd.DataFrame({"product_cost": [100, 200, 300]})
+    assert fingerprinting.hash_value(revenue) != fingerprinting.hash_value(cost)
+
+
+def test_hash_pandas_distinguishes_series_names():
+    """Two Series with identical values but different names must not collide."""
+    s_revenue = pd.Series([100, 200, 300], name="customer_revenue")
+    s_cost = pd.Series([100, 200, 300], name="product_cost")
+    assert fingerprinting.hash_value(s_revenue) != fingerprinting.hash_value(s_cost)
+
+
+def test_hash_polars_distinguishes_column_names():
+    """Two polars DataFrames with identical row values but different
+    column names must not collide.
+    """
+    pl = pytest.importorskip("polars")
+    revenue = pl.DataFrame({"customer_revenue": [100, 200, 300]})
+    cost = pl.DataFrame({"product_cost": [100, 200, 300]})
+    assert fingerprinting.hash_value(revenue) != fingerprinting.hash_value(cost)
+
+
+def test_hash_polars_distinguishes_series_names():
+    """Two polars Series with identical values but different names must not collide."""
+    pl = pytest.importorskip("polars")
+    s_revenue = pl.Series("customer_revenue", [100, 200, 300])
+    s_cost = pl.Series("product_cost", [100, 200, 300])
+    assert fingerprinting.hash_value(s_revenue) != fingerprinting.hash_value(s_cost)
+
+
+def test_hash_pandas_stable_across_identical_copies():
+    """Sanity: identical inputs still hash equal (cache hits work)."""
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    assert fingerprinting.hash_value(df) == fingerprinting.hash_value(df.copy())
+
+
+def test_hash_numpy_stable_across_identical_copies():
+    """Sanity: identical numpy arrays still hash equal (cache hits work)."""
+    arr = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64)
+    assert fingerprinting.hash_value(arr) == fingerprinting.hash_value(arr.copy())
+
+
+def test_hash_polars_stable_across_identical_copies():
+    """Sanity: identical polars DataFrames still hash equal (cache hits work)."""
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    assert fingerprinting.hash_value(df) == fingerprinting.hash_value(df.clone())


### PR DESCRIPTION
## Summary

The numpy, pandas, and polars fingerprint hashes in `hamilton/caching/fingerprinting.py` previously hashed only the underlying values, dropping shape, dtype, column names, and Series names. This caused cache key collisions between semantically distinct inputs:

- `np.array([1,2,3,4,5,6])` vs `np.array([[1,2,3],[4,5,6]])` (same `.tobytes()`, different shapes)
- `np.array([1,2,3], int32)` vs `np.array([1,0,2,0,3,0], int16)` (same bytes, different dtypes)
- `pd.DataFrame({"customer_revenue": [100,200]})` vs `pd.DataFrame({"product_cost": [100,200]})` (same row values, different column names)
- Same pattern for polars

With caching enabled, the cache returned the prior result for the second input silently — producing incorrect outputs with no warning.

## What this PR does

- `hash_numpy_array`: prepends `shape` and `dtype` to the byte buffer.
- `hash_polars_dataframe`: includes `obj.schema` alongside row hashes.
- `hash_pandas_obj`: includes `(column, dtype)` pairs (DataFrame) or `(name, dtype)` (Series/Index) alongside row hashes.

## Test plan

- 8 new regression tests in `tests/caching/test_fingerprinting.py` covering each collision case + identical-input determinism.
- Updated `test_hash_pandas` and `test_hash_numpy` golden hashes for the new schema-aware computation.
- All 117 `tests/caching/` tests pass locally.