### PR TITLE
Remove `flit` from prereq check since handled by uvx

### DIFF
--- a/scripts/verify-sub-packages/verify_contrib.sh
+++ b/scripts/verify-sub-packages/verify_contrib.sh
@@ -40,7 +40,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Check prerequisites
-for cmd in gpg java flit uv svn; do
+for cmd in gpg java uv svn; do
     if ! command -v "$cmd" > /dev/null 2>&1; then
         echo "ERROR: $cmd is required but not found. Please install it."
         exit 1

--- a/scripts/verify-sub-packages/verify_lsp.sh
+++ b/scripts/verify-sub-packages/verify_lsp.sh
@@ -40,7 +40,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Check prerequisites
-for cmd in gpg java flit uv svn; do
+for cmd in gpg java uv svn; do
     if ! command -v "$cmd" > /dev/null 2>&1; then
         echo "ERROR: $cmd is required but not found. Please install it."
         exit 1

--- a/scripts/verify-sub-packages/verify_sdk.sh
+++ b/scripts/verify-sub-packages/verify_sdk.sh
@@ -40,7 +40,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Check prerequisites
-for cmd in gpg java flit uv svn; do
+for cmd in gpg java uv svn; do
     if ! command -v "$cmd" > /dev/null 2>&1; then
         echo "ERROR: $cmd is required but not found. Please install it."
         exit 1

--- a/scripts/verify-sub-packages/verify_ui.sh
+++ b/scripts/verify-sub-packages/verify_ui.sh
@@ -40,7 +40,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Check prerequisites
-for cmd in gpg java flit uv svn; do
+for cmd in gpg java uv svn; do
     if ! command -v "$cmd" > /dev/null 2>&1; then
         echo "ERROR: $cmd is required but not found. Please install it."
         exit 1


### PR DESCRIPTION
Since `flit` is executed via `uvx`, checking for `uv` is sufficient.

## Changes
Remove `flit` from prereq check in the 4 subpackage verification scripts.

## How I tested this
Successfully ran `scripts/verify-sub-packages/verify_sdk.sh 0.9.0 1` in a venv where flit is not installed.

## Notes
N/A

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
