### PR TITLE
fix(tests): tolerate numpy pre-release versions in test_node

### DIFF
--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -21,6 +21,7 @@ from typing import Any, Literal, TypeVar
 import numpy as np
 import numpy.typing as npt
 import pytest
+from packaging.version import Version
 
 from hamilton import node
 from hamilton.node import DependencyType, Node, matches_query
@@ -60,8 +61,8 @@ def test_node_copy_with_retains_originating_functions():
     assert node_copy_copy.name == "rename_fn_again"
 
 
-np_version = np.__version__
-major, minor, _ = map(int, np_version.split("."))
+np_version = Version(np.__version__)
+major, minor = np_version.major, np_version.minor
 
 
 def test_node_handles_annotated():
@@ -84,6 +85,15 @@ def test_node_handles_annotated():
             "other": (float, DependencyType.OPTIONAL),
         }
         expected_type = Annotated[np.ndarray[tuple[int, ...], np.dtype[np.float64]], Literal["N"]]
+    elif (major, minor) >= (2, 5):
+        expected = {
+            "first": (
+                Annotated[npt.NDArray[np.float64], Literal["N"]],
+                DependencyType.REQUIRED,
+            ),
+            "other": (float, DependencyType.OPTIONAL),
+        }
+        expected_type = Annotated[npt.NDArray[np.float64], Literal["N"]]
     elif (major, minor) >= (2, 4):  # numpy 2.4+
         expected = {
             "first": (


### PR DESCRIPTION
## Changes
 - Tests fail due to manual split of np version on `.` which fails on annotated versions like `2.5.0rc1`.
 - Move to packaging `Version` to avoid this

## How I tested this
 - CI
## Notes

## Checklist

- [X] PR has an informative and human-readable title (this will be pulled into the release notes)
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future TODOs are captured in comments
- [X] Project documentation has been updated if adding/changing functionality.
