### PR TITLE
Switch the fingerprint algo to xxh3_128

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -226,33 +226,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
--------------------------------
-
-This product depends on xxhash (the python-xxhash package, https://github.com/ifduyue/python-xxhash),
-which is licensed under the BSD 2-Clause License.
-
-BSD 2-Clause License
-
-Copyright (c) 2014-2024, Yue Du
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -226,3 +226,33 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+-------------------------------
+
+This product depends on xxhash (the python-xxhash package, https://github.com/ifduyue/python-xxhash),
+which is licensed under the BSD 2-Clause License.
+
+BSD 2-Clause License
+
+Copyright (c) 2014-2024, Yue Du
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/concepts/caching.rst
+++ b/docs/concepts/caching.rst
@@ -357,6 +357,21 @@ Data version
 
 Caching requires the ability to uniquely identify data (e.g., create a hash). By default, all Python primitive types (``int``, ``str``, ``dict``, etc.) are supported and more types can be added via extensions (e.g., ``pandas``). For types not explicitly supported, caching can still function by versioning the object's internal ``__dict__`` instead. However, this could be expensive to compute or less reliable than alternatives.
 
+Hashing backend
+~~~~~~~~~~~~~~~
+
+By default, hashing uses the standard library's ``hashlib.md5`` (chosen for speed, not for cryptographic security). Installing the optional `xxhash <https://github.com/ifduyue/python-xxhash>`_ dependency switches the backend to ``xxhash.xxh3_128``, which is substantially faster on buffer-bound paths (e.g. numpy arrays, polars DataFrames):
+
+.. code-block:: console
+
+    pip install "apache-hamilton[performance]"
+
+Both backends produce a 16-byte digest, so cache keys and ``data_version`` strings are unaffected in shape. However, the two algorithms produce different digests for the same input, so **installing or removing xxhash changes every ``data_version`` in your dataflow**, invalidating previously persisted caches. Cached results are just recomputed on the next run, at the cost of losing the benefit of the existing cache.
+
+.. note::
+
+    Because the resolved backend is process-wide, keep it consistent across the environments that share a cache (e.g. all workers writing to the same cache store) to avoid needless cache misses.
+
 Recursion depth
 ~~~~~~~~~~~~~~~
 

--- a/hamilton/caching/fingerprinting.py
+++ b/hamilton/caching/fingerprinting.py
@@ -36,10 +36,11 @@ implementation should pass the `depth` parameter to prevent `RecursionError`.
 import base64
 import datetime
 import functools
-import hashlib
 import logging
 import sys
 from collections.abc import Mapping, Sequence, Set
+
+import xxhash
 
 from hamilton.experimental import h_databackends
 
@@ -77,12 +78,16 @@ def _compact_hash(digest: bytes) -> str:
 
 
 def _hash_bytes(data: bytes) -> str:
-    """Hash raw bytes and compact-encode the digest.
+    """Hash raw bytes with the non-cryptographic xxh3_128 algorithm and
+    compact-encode the digest.
 
     All hashing in this module routes through this single helper so the
     underlying hashing algorithm can be changed in exactly one place.
+    xxh3_128 produces a 16-byte digest (24 base64url chars, the same width
+    as the md5 it replaces) while running substantially faster on
+    buffer-bound paths.
     """
-    return _compact_hash(hashlib.md5(data).digest())
+    return _compact_hash(xxhash.xxh3_128(data).digest())
 
 
 @functools.singledispatch

--- a/hamilton/caching/fingerprinting.py
+++ b/hamilton/caching/fingerprinting.py
@@ -33,14 +33,15 @@ IMPORTANT all container types that make a recursive call to `hash_value` or a sp
 implementation should pass the `depth` parameter to prevent `RecursionError`.
 """
 
+from __future__ import annotations
+
 import base64
 import datetime
 import functools
 import logging
 import sys
 from collections.abc import Mapping, Sequence, Set
-
-import xxhash
+from typing import TYPE_CHECKING
 
 from hamilton.experimental import h_databackends
 
@@ -50,6 +51,31 @@ try:
 except ImportError:
     NoneType = type(None)
 
+if TYPE_CHECKING:
+    from collections.abc import Buffer, Callable
+    from typing import Protocol
+
+    class Hash(Protocol):
+        def digest(self) -> bytes: ...
+
+
+hash_func: Callable[[str | Buffer], Hash]
+try:
+    # xxh3_128 produces a 16-byte digest (24 base64url chars, the same width as the
+    # md5 it replaces) while running substantially faster on buffer-bound paths.
+    # TODO(2.0): revisit once/if a dependency-free `apache-hamilton-core` package
+    # exists, so this optional performance dependency lands in the right tier.
+    import xxhash
+
+    hash_func = xxhash.xxh3_128
+except (ModuleNotFoundError, AttributeError):
+    # ModuleNotFoundError covers xxhash not being installed; AttributeError
+    # covers an xxhash older than 0.8.0 (which added xxh3_128).
+    # usedforsecurity=False avoids a ValueError on FIPS-mode Python; it
+    # doesn't change the digest.
+    import hashlib
+
+    hash_func = functools.partial(hashlib.md5, usedforsecurity=False)
 
 logger = logging.getLogger("hamilton.caching")
 
@@ -78,16 +104,20 @@ def _compact_hash(digest: bytes) -> str:
 
 
 def _hash_bytes(data: bytes) -> str:
-    """Hash raw bytes with the non-cryptographic xxh3_128 algorithm and
-    compact-encode the digest.
+    """Hash raw bytes and compact-encode the digest.
 
     All hashing in this module routes through this single helper so the
     underlying hashing algorithm can be changed in exactly one place.
-    xxh3_128 produces a 16-byte digest (24 base64url chars, the same width
-    as the md5 it replaces) while running substantially faster on
-    buffer-bound paths.
+
+    Uses the non-cryptographic xxh3_128 algorithm when the optional
+    ``xxhash`` package is installed (see the ``performance`` extra),
+    falling back to hashlib's md5 otherwise. Both produce a 16-byte digest
+    (24 base64url chars), so digest width is unaffected either way, but the
+    two algorithms don't produce the same bytes for the same input:
+    fingerprints are stable within an environment, not across installs with
+    a different backend.
     """
-    return _compact_hash(xxhash.xxh3_128(data).digest())
+    return _compact_hash(hash_func(data).digest())
 
 
 @functools.singledispatch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "pandas",
     "typing_extensions > 4.0.0",
     "typing_inspect",
+    "xxhash>=0.8.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "pandas",
     "typing_extensions > 4.0.0",
     "typing_inspect",
-    "xxhash>=0.8.0",
 ]
 
 [project.optional-dependencies]
@@ -71,6 +70,10 @@ experiments = [
 lsp = ["apache-hamilton-lsp"]
 openlineage = ["openlineage-python"]
 pandera = ["pandera"]
+performance = [
+    # Internal performance boosters go here
+    "xxhash>=0.8.0",
+]
 pydantic = ["pydantic>=2.0"]
 pyspark = [
   # we have to run these dependencies because Spark does not check to ensure the right target was called
@@ -135,6 +138,7 @@ test = [
   "xgboost; python_version < '3.14'",
   "xlsx2csv", # for excel data loader
   "xlsxwriter",  # Excel export requires 'xlsxwriter'
+  "xxhash>=0.8.0", # exercises the high-performance fingerprinting path in tests
 ]
 docs = [
   {include-group = "dev"},

--- a/tests/caching/test_fingerprinting.py
+++ b/tests/caching/test_fingerprinting.py
@@ -146,11 +146,11 @@ def test_max_recursion_depth():
 @pytest.mark.parametrize(
     ("obj", "expected_hash"),
     [
-        ("hello-world", "L1Q1Kh6_t1atHO_H8RbBeA=="),
-        (17.31231, "mJPTpPyXDSZgU-u8NuztIQ=="),
-        (16474, "6MgAp1NbMW0ZZpe_8iKVsg=="),
-        (True, "J2eGynSuIpd5bwVQzO9VVg=="),
-        (b"\x951!\x89u=\xe6\xadG\xdf", "d1DufDgRQmqi9Kt4Z2PeUQ=="),
+        ("hello-world", "EXXR8_e47ElS18aP2lThJA=="),
+        (17.31231, "tVUSIslYiBcW52c-7w4gvA=="),
+        (16474, "FAJ-iXM_Hwg9TCRreY8AyA=="),
+        (True, "qkJEg3-XQKmGWk5sWqmonw=="),
+        (b"\x951!\x89u=\xe6\xadG\xdf", "pPTyYkSU_x7NLB1Fp_YTyA=="),
     ],
 )
 def test_hash_primitive(obj, expected_hash):
@@ -161,8 +161,8 @@ def test_hash_primitive(obj, expected_hash):
 @pytest.mark.parametrize(
     ("obj", "expected_hash"),
     [
-        ([0, True, "hello-world"], "mlOjj4yeCrSDFSn5zgdEIg=="),
-        ((17.0, False, "world"), "BcRSGfyKeIOdym9B6TmAyQ=="),
+        ([0, True, "hello-world"], "I98OkNhfxtScJrYNTs4ZfQ=="),
+        ((17.0, False, "world"), "catgOMSnsbQj1_KELNQscw=="),
     ],
 )
 def test_hash_sequence(obj, expected_hash):
@@ -173,7 +173,7 @@ def test_hash_sequence(obj, expected_hash):
 def test_hash_equals_for_different_sequence_types():
     list_obj = [0, True, "hello-world"]
     tuple_obj = (0, True, "hello-world")
-    expected_hash = "mlOjj4yeCrSDFSn5zgdEIg=="
+    expected_hash = "I98OkNhfxtScJrYNTs4ZfQ=="
 
     list_fingerprint = fingerprinting.hash_sequence(list_obj)
     tuple_fingerprint = fingerprinting.hash_sequence(tuple_obj)
@@ -182,7 +182,7 @@ def test_hash_equals_for_different_sequence_types():
 
 def test_hash_ordered_mapping():
     obj = {0: True, "key": "value", 17.0: None}
-    expected_hash = "GyxyI9-pq-EJJvSAIN509g=="
+    expected_hash = "zX6MzhWGAOvxateHIPxOvA=="
     fingerprint = fingerprinting.hash_mapping(obj, ignore_order=False)
     assert fingerprint == expected_hash
 
@@ -197,7 +197,7 @@ def test_hash_mapping_where_order_matters():
 
 def test_hash_unordered_mapping():
     obj = {0: True, "key": "value", 17.0: None}
-    expected_hash = "cDuuL2eA3DaSWlWW3u7o9g=="
+    expected_hash = "4cnTFA4MEEzmBN4a04k6tA=="
     fingerprint = fingerprinting.hash_mapping(obj, ignore_order=True)
     assert fingerprint == expected_hash
 
@@ -212,7 +212,7 @@ def test_hash_mapping_where_order_doesnt_matter():
 
 def test_hash_set():
     obj = {0, True, "key", "value", 17.0, None}
-    expected_hash = "E_f_tjbi6qn7KL3NUCZayg=="
+    expected_hash = "mswHhNBBYN5mv6i-LcEeVw=="
     fingerprint = fingerprinting.hash_set(obj)
     assert fingerprint == expected_hash
 
@@ -221,7 +221,7 @@ def test_hash_numpy():
     # dtype is pinned explicitly so the literal digest is reproducible across
     # platforms (the default integer dtype is platform-dependent).
     array = np.array([[0, 1], [2, 3]], dtype=np.int64)
-    expected_hash = "024zwZIcWy6r4dlX4AMTow=="
+    expected_hash = "Y1uek_eQTHejo2YtRvdWPQ=="
     fingerprint = fingerprinting.hash_value(array)
     assert fingerprint == expected_hash
 

--- a/tests/caching/test_fingerprinting.py
+++ b/tests/caching/test_fingerprinting.py
@@ -20,11 +20,26 @@ complex types, many tests are not "true" unit tests. The base cases are
 the original `hash_value()` and the `hash_primitive()` functions.
 """
 
+import functools
+import hashlib
+import importlib
+import sys
+import types
+
 import numpy as np
 import pandas as pd
 import pytest
 
 from hamilton.caching import fingerprinting
+
+
+@pytest.fixture
+def force_md5_backend(monkeypatch):
+    """Force the hashlib.md5 fallback backend, regardless of whether xxhash
+    is installed in the current environment."""
+    monkeypatch.setattr(
+        fingerprinting, "hash_func", functools.partial(hashlib.md5, usedforsecurity=False)
+    )
 
 
 def test_hash_none():
@@ -224,6 +239,123 @@ def test_hash_numpy():
     expected_hash = "Y1uek_eQTHejo2YtRvdWPQ=="
     fingerprint = fingerprinting.hash_value(array)
     assert fingerprint == expected_hash
+
+
+# ---------------------------------------------------------------------------
+# hashlib.md5 fallback backend
+#
+# These mirror the pinned tests above but force `hash_func` to the hashlib.md5
+# fallback (via the `force_md5_backend` fixture) so the fallback path used
+# when `xxhash` isn't installed is verified regardless of what's installed in
+# the environment running the suite. Expected digests are the pre-xxh3_128
+# values this module used before xxhash became the default backend.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("force_md5_backend")
+@pytest.mark.parametrize(
+    ("obj", "expected_hash"),
+    [
+        ("hello-world", "L1Q1Kh6_t1atHO_H8RbBeA=="),
+        (17.31231, "mJPTpPyXDSZgU-u8NuztIQ=="),
+        (16474, "6MgAp1NbMW0ZZpe_8iKVsg=="),
+        (True, "J2eGynSuIpd5bwVQzO9VVg=="),
+        (b"\x951!\x89u=\xe6\xadG\xdf", "d1DufDgRQmqi9Kt4Z2PeUQ=="),
+    ],
+)
+def test_hash_primitive_md5_fallback(obj, expected_hash):
+    fingerprint = fingerprinting.hash_primitive(obj)
+    assert fingerprint == expected_hash
+
+
+@pytest.mark.usefixtures("force_md5_backend")
+@pytest.mark.parametrize(
+    ("obj", "expected_hash"),
+    [
+        ([0, True, "hello-world"], "mlOjj4yeCrSDFSn5zgdEIg=="),
+        ((17.0, False, "world"), "BcRSGfyKeIOdym9B6TmAyQ=="),
+    ],
+)
+def test_hash_sequence_md5_fallback(obj, expected_hash):
+    fingerprint = fingerprinting.hash_sequence(obj)
+    assert fingerprint == expected_hash
+
+
+@pytest.mark.usefixtures("force_md5_backend")
+def test_hash_ordered_mapping_md5_fallback():
+    obj = {0: True, "key": "value", 17.0: None}
+    expected_hash = "GyxyI9-pq-EJJvSAIN509g=="
+    fingerprint = fingerprinting.hash_mapping(obj, ignore_order=False)
+    assert fingerprint == expected_hash
+
+
+@pytest.mark.usefixtures("force_md5_backend")
+def test_hash_unordered_mapping_md5_fallback():
+    obj = {0: True, "key": "value", 17.0: None}
+    expected_hash = "cDuuL2eA3DaSWlWW3u7o9g=="
+    fingerprint = fingerprinting.hash_mapping(obj, ignore_order=True)
+    assert fingerprint == expected_hash
+
+
+@pytest.mark.usefixtures("force_md5_backend")
+def test_hash_set_md5_fallback():
+    obj = {0, True, "key", "value", 17.0, None}
+    expected_hash = "E_f_tjbi6qn7KL3NUCZayg=="
+    fingerprint = fingerprinting.hash_set(obj)
+    assert fingerprint == expected_hash
+
+
+@pytest.mark.usefixtures("force_md5_backend")
+def test_hash_numpy_md5_fallback():
+    array = np.array([[0, 1], [2, 3]], dtype=np.int64)
+    expected_hash = "024zwZIcWy6r4dlX4AMTow=="
+    fingerprint = fingerprinting.hash_value(array)
+    assert fingerprint == expected_hash
+
+
+def test_hash_bytes_digest_width():
+    """Both backends produce a 16-byte digest (24 base64url chars), so swapping
+    the algorithm doesn't change the shape of cache keys / `data_version` strings.
+    """
+    assert len(fingerprinting._hash_bytes(b"x")) == 24
+
+
+@pytest.mark.usefixtures("force_md5_backend")
+def test_hash_bytes_digest_width_md5_fallback():
+    assert len(fingerprinting._hash_bytes(b"x")) == 24
+
+
+# ---------------------------------------------------------------------------
+# Import-time backend resolution
+#
+# These reload the module to actually exercise the try/except at import time
+# (as opposed to `force_md5_backend`, which only overrides the already-resolved
+# `hash_func`), then restore the module to its real, ambient-environment state
+# so later tests aren't affected.
+# ---------------------------------------------------------------------------
+
+
+def test_falls_back_when_xxhash_not_installed(monkeypatch):
+    """Simulate xxhash being absent: `import xxhash` raises ModuleNotFoundError."""
+    monkeypatch.setitem(sys.modules, "xxhash", None)
+    try:
+        reloaded = importlib.reload(fingerprinting)
+        assert reloaded.hash_func.func is hashlib.md5
+        assert reloaded.hash_func.keywords == {"usedforsecurity": False}
+    finally:
+        importlib.reload(fingerprinting)
+
+
+def test_falls_back_when_xxhash_lacks_xxh3_128(monkeypatch):
+    """Simulate an xxhash older than 0.8.0, which doesn't define xxh3_128."""
+    stub = types.ModuleType("xxhash")
+    monkeypatch.setitem(sys.modules, "xxhash", stub)
+    try:
+        reloaded = importlib.reload(fingerprinting)
+        assert reloaded.hash_func.func is hashlib.md5
+        assert reloaded.hash_func.keywords == {"usedforsecurity": False}
+    finally:
+        importlib.reload(fingerprinting)
 
 
 def test_hash_numpy_different_shapes_differ():


### PR DESCRIPTION
Split 3 of 3 of #1619 (stacked on #1629)

1. centralize hashing through a single chokepoint + close type collisions (#1628).
2. vectorize the pandas/polars DataFrame paths (#1629).
3. **this PR** — swap the algorithm to `xxhash.xxh3_128`.

## What this does

Change in `_hash_bytes`: when xxhash is installed, the runtime path changes `hashlib.md5(data).digest()` → `xxhash.xxh3_128(data).digest()`.  `xxh3_128` is a non-cryptographic hash designed for speed. It produces a 16-byte (128-bit) digest, the same width as md5, so the base64url-encoded fingerprints stay 24 characters and all downstream interfaces (cache keys, `data_version` strings) are unaffected.

Adds `xxhash>=0.8.0` as an optional dependency in `pyproject.toml` (under the `performance` extra).

## Benchmark

<details><summary>Benchmark code</summary>
<p>

~~~python
# benchmark_hash_algorithm.py
"""Benchmark: xxh3_128 vs md5 on the vectorized DataFrame fingerprint path.

Holds the (vectorized) implementation constant and varies only the hashing
algorithm applied by ``_hash_bytes``, to quantify what switching md5 -> xxh3_128
buys:

  * "hash-step": md5 vs xxh3_128 over the row-hash buffer alone. This is the
    raw algorithm advantage and the ceiling on any end-to-end gain.
  * "end-to-end": the full vectorized fingerprint, comparing the current
    xxh3_128 functions against an md5 reconstruction of the same construction.
    Buffer construction (``hash_pandas_object`` / ``hash_rows``) is identical
    under either algorithm, so this is the realistic improvement on the hot
    path once that fixed cost is included.

Informational only (no pass/fail gate). Run directly:

    python benchmarks/benchmark_hash_algorithm.py
"""

import base64
import hashlib
import os
import platform
import re
import time

import numpy as np
import pandas as pd
import xxhash

from hamilton.caching import fingerprinting as fp

# Swept so the realized speedup can be read as a function of buffer size.
SIZES = (500, 5_000, 50_000, 500_000, 5_000_000)


def _cpu_model() -> str:
    try:
        with open("/proc/cpuinfo") as f:
            for line in f:
                if line.startswith("model name"):
                    return line.split(":", 1)[1].strip()
    except OSError:
        pass
    return platform.processor() or "unknown"


def _ram_info() -> str:
    import subprocess

    total = "unknown"
    try:
        with open("/proc/meminfo") as f:
            for line in f:
                if line.startswith("MemTotal"):
                    kb = int(re.search(r"\d+", line).group())
                    total = f"{kb / 1024 / 1024:.0f} GiB"
                    break
    except OSError:
        pass
    detail = ""
    try:
        out = subprocess.check_output(
            ["dmidecode", "-t", "memory"], text=True, stderr=subprocess.DEVNULL,
        )
        typ = re.search(r"^\s*Type:\s*(DDR\S*)", out, re.MULTILINE)
        spd = re.search(r"^\s*Configured Memory Speed:\s*(\d+\s*\S+)", out, re.MULTILINE)
        if not spd:
            spd = re.search(r"^\s*Speed:\s*(\d+\s*\S+)", out, re.MULTILINE)
        parts = [m.group(1) for m in (typ, spd) if m]
        if parts:
            detail = f" ({' '.join(parts)})"
    except (OSError, subprocess.CalledProcessError):
        pass
    return f"{total}{detail}"


def _print_env() -> None:
    import sys

    import polars as pl

    print("== Environment ==")
    print(f"  CPU      : {_cpu_model()} ({os.cpu_count()} logical cores)")
    print(f"  RAM      : {_ram_info()}")
    print(f"  Platform : {platform.system()} {platform.release()} ({platform.machine()})")
    print(f"  Python   : {sys.version.split()[0]}")
    print(f"  numpy    : {np.__version__}")
    print(f"  pandas   : {pd.__version__}")
    print(f"  polars   : {pl.__version__}")
    print(f"  xxhash   : {xxhash.VERSION}")
    print()


def _md5_compact(data: bytes) -> str:
    return base64.urlsafe_b64encode(hashlib.md5(data).digest()).decode()


def _numpy_md5(obj) -> str:
    """The numpy path, but hashing the buffer with md5.

    Unlike the DataFrame paths there is no per-row baseline to remove: numpy has
    always hashed ``shape:dtype`` + raw ``tobytes()`` in one shot. Even so the
    end-to-end speedup is bounded well below the raw algorithm speedup, because
    materializing the buffer (``tobytes()`` + concatenation) is a memcpy that
    costs about as much as md5 hashing it.
    """
    metadata = f"{obj.shape}:{obj.dtype}".encode()
    return _md5_compact(b"bytes:" + metadata + obj.tobytes())


def _vectorized_pandas_md5(obj) -> str:
    """The vectorized pandas path, but hashing the buffer with md5."""
    from pandas.util import hash_pandas_object

    row_hashes = hash_pandas_object(obj).values.tobytes()
    if hasattr(obj, "columns"):
        schema = f"{list(obj.columns)}:{[str(dtype) for dtype in obj.dtypes]}"
    else:
        schema = f"{getattr(obj, 'name', None)}:{obj.dtype}"
    return _md5_compact(schema.encode() + row_hashes)


def _vectorized_polars_md5(obj) -> str:
    """The vectorized polars path, but hashing the buffers with md5."""
    schema_str = ",".join(f"{name}:{dtype}" for name, dtype in obj.schema.items())
    schema_hash = _md5_compact(b"bytes:" + schema_str.encode())
    row_hash = _md5_compact(b"bytes:" + obj.hash_rows().to_numpy().tobytes())
    return _md5_compact(schema_hash.encode() + row_hash.encode())


def _time(fn, obj, repeats: int = 3) -> float:
    fn(obj)  # warmup
    best = float("inf")
    for _ in range(repeats):
        start = time.perf_counter()
        fn(obj)
        best = min(best, time.perf_counter() - start)
    return best


def _report_hash_step(label: str, n_rows: int, buffer: bytes) -> None:
    mib = len(buffer) / 1024 / 1024
    md5_t = _time(lambda b: hashlib.md5(b).digest(), buffer)
    xxh_t = _time(lambda b: xxhash.xxh3_128(b).digest(), buffer)
    print(
        f"[{label} n={n_rows:>9,}] hash-step  md5 {md5_t * 1e3:8.3f} ms ({mib / md5_t:>7,.0f} MiB/s)"
        f"  xxh3 {xxh_t * 1e3:7.3f} ms ({mib / xxh_t:>7,.0f} MiB/s)  speedup {md5_t / xxh_t:5.1f}x"
    )


def _report_end_to_end(label: str, n_rows: int, md5_fn, xxh_fn, obj) -> None:
    md5_t = _time(md5_fn, obj)
    xxh_t = _time(xxh_fn, obj)
    print(
        f"[{label} n={n_rows:>9,}] end-to-end md5 {md5_t * 1e3:8.1f} ms"
        f"  xxh3 {xxh_t * 1e3:8.1f} ms  speedup {md5_t / xxh_t:5.2f}x"
    )


def _columns(n_rows: int) -> dict:
    return {
        "a": range(n_rows),
        "b": [float(i) for i in range(n_rows)],
        "c": [f"row-{i}" for i in range(n_rows)],
    }


def main() -> None:
    _print_env()

    from pandas.util import hash_pandas_object

    try:
        import polars as pl
    except ImportError:
        pl = None
        print("[polars] not installed; skipping polars")

    for n_rows in SIZES:
        columns = _columns(n_rows)

        arr = np.arange(n_rows, dtype=np.int64)
        _report_hash_step("numpy ", n_rows, arr.tobytes())
        _report_end_to_end("numpy ", n_rows, _numpy_md5, fp.hash_value, arr)

        df = pd.DataFrame(columns)
        _report_hash_step("pandas", n_rows, hash_pandas_object(df).values.tobytes())
        _report_end_to_end("pandas", n_rows, _vectorized_pandas_md5, fp.hash_pandas_obj, df)

        if pl is not None:
            pdf = pl.DataFrame(columns)
            _report_hash_step("polars", n_rows, pdf.hash_rows().to_numpy().tobytes())
            _report_end_to_end(
                "polars", n_rows, _vectorized_polars_md5, fp.hash_polars_dataframe, pdf
            )


if __name__ == "__main__":
    main()

~~~

</p>
</details> 


<details><summary>Plotting code</summary>
<p>

~~~python
# plot_benchmarks.py
"""Generate Plotly charts for PR2 and PR3 benchmark results.

Reads hardcoded benchmark data (not recomputed) and writes two PNG files
into the same directory as this script.

    python benchmarks/plot_benchmarks.py
"""

from pathlib import Path

import plotly.graph_objects as go

OUT_DIR = Path(__file__).parent

SIZE_LABELS = ["500", "5 K", "50 K", "500 K", "5 M"]

COLORS = {
    "pandas": "#1f77b4",
    "polars": "#ff7f0e",
    "numpy": "#2ca02c",
}

# ── PR2 data (baseline → vectorized) ────────────────────────────────────
PR2 = {
    "pandas": [4.2, 11.0, 12.5, 9.8, 6.0],
    "polars": [13.1, 78.1, 382.0, 431.0, 209.0],
}

# ── PR3 data (md5 → xxh3_128, end-to-end) ───────────────────────────────
PR3 = {
    "numpy": [1.36, 3.21, 6.45, 1.44, 1.55],
    "pandas": [1.03, 0.88, 0.98, 1.00, 1.00],
    "polars": [1.25, 1.84, 2.26, 2.26, 1.67],
}


def _build_chart(data: dict, title: str, log_y: bool = False) -> go.Figure:
    fig = go.Figure()

    for backend, speedups in data.items():
        fig.add_trace(
            go.Scatter(
                name=backend,
                x=SIZE_LABELS,
                y=speedups,
                mode="lines+markers+text",
                text=[f"{s:.1f}×" for s in speedups],
                textposition="top center",
                textfont=dict(size=12),
                line=dict(color=COLORS[backend], width=3),
                marker=dict(size=10),
            )
        )

    fig.update_layout(
        title=dict(text=title, x=0.5, y=0.95, yanchor="top"),
        legend=dict(
            yanchor="top",
            y=0.98,
            xanchor="left",
            x=0.02,
            bgcolor="rgba(255,255,255,0.8)",
        ),
        template="plotly_white",
        height=500,
        width=800,
        margin=dict(t=60, b=60),
    )
    fig.update_xaxes(title_text="Input size (rows)")
    fig.update_yaxes(title_text="Speedup (×)", type="log" if log_y else "linear")

    return fig


def main() -> None:
    pr2_fig = _build_chart(
        PR2,
        title="PR2: Vectorized hashing — speedup over per-row baseline",
        log_y=True,
    )
    pr2_path = OUT_DIR / "PR2_chart.png"
    pr2_fig.write_image(str(pr2_path), scale=2)
    print(f"Wrote {pr2_path}")

    pr3_fig = _build_chart(
        PR3,
        title="PR3: xxh3_128 vs md5 — end-to-end speedup",
    )
    pr3_path = OUT_DIR / "PR3_chart.png"
    pr3_fig.write_image(str(pr3_path), scale=2)
    print(f"Wrote {pr3_path}")


if __name__ == "__main__":
    main()

~~~

</p>
</details> 

`benchmark_hash_algorithm.py` isolates the algorithm swap from the vectorization (#1629), holding the implementation constant and varying only the hash. The raw algorithm is ~8–27× faster, but **the end-to-end gain depends on how much of total time the hash step occupies**:

| rows | backend | md5 (ms) | xxh3 (ms) | speedup |
|-----:|---------|--------:|---------:|--------:|
| 500       | numpy  | 0.03    | 0.02    | **1.4×** |
| 500       | pandas | 1.0     | 1.0     | **1.0×** |
| 500       | polars | 0.1     | 0.1     | **1.3×** |
| 5,000     | numpy  | 0.1     | 0.03    | **3.2×** |
| 5,000     | pandas | 2.9     | 3.3     | **0.9×** |
| 5,000     | polars | 0.2     | 0.1     | **1.8×** |
| 50,000    | numpy  | 0.6     | 0.1     | **6.5×** |
| 50,000    | pandas | 32.3    | 33.0    | **1.0×** |
| 50,000    | polars | 0.9     | 0.4     | **2.3×** |
| 500,000   | numpy  | 9.4     | 6.5     | **1.4×** |
| 500,000   | pandas | 382     | 382     | **1.0×** |
| 500,000   | polars | 9.5     | 4.2     | **2.3×** |
| 5,000,000 | numpy  | 96.3    | 62.0    | **1.6×** |
| 5,000,000 | pandas | 6,434   | 6,405   | **1.0×** |
| 5,000,000 | polars | 121     | 72.6    | **1.7×** |

> CPU: Intel i7-3770 @ 3.40 GHz · 32 GiB DDR3-1600 · pandas 3.0.3 · polars 1.41.2 · xxhash 3.7.0 · Python 3.14.2

<img width="1600" height="1000" alt="PR3_chart" src="https://github.com/user-attachments/assets/d3c4395b-ea1c-4699-a721-dcfa00ce1767" />

**pandas DataFrames: ~1× (negligible) at all sizes.** `hash_pandas_object` takes 1–6,400 ms; the hash step takes 0.006–52 ms with md5. Hashing is ≤1.5% of end-to-end time. The algorithm swap is invisible here.

**polars DataFrames: 1.3–2.3×.** `hash_rows` is fast enough that the hash step is a meaningful fraction of end-to-end time. The gain grows with size as the hash step's share increases.

**numpy arrays: 1.4–6.5×.** Peaks at mid sizes (~50k) where `tobytes()` is negligible and hashing dominates; at very small sizes per-call overhead limits the gain, at large sizes the memcpy dominates.

**Scalars, sequences, mappings (not benchmarked in isolation):** estimated ~1.4–2×, dominated by per-call overhead and base64 encoding. These are the most frequent fingerprint calls in a typical DAG (node inputs, configs, primitives).

## Why this is still worth landing

1. **Every `_hash_bytes` call gets faster** — the benefit is broadest on the many small-buffer paths (scalars, sequences, configs) even though it's invisible on pandas DataFrames.
1. **Semantic fit.** md5 is a (broken) cryptographic hash misused for speed; xxh3_128 is a non-cryptographic hash designed for exactly this use case.

## Testing

Pinned-digest literals in `test_fingerprinting.py` are updated to the new xxh3_128 values. Relational tests (must-differ, must-match, cross-type collision) and the full caching suite pass unchanged.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
