### PR TITLE
Harden release + verify scripts for SVN upload and local artifact dirs

### DIFF
--- a/scripts/apache_release_helper.py
+++ b/scripts/apache_release_helper.py
@@ -456,7 +456,9 @@ def create_release_artifacts(package_config: dict, version, no_sign: bool = Fals
             wheel_signed_files = sign_artifacts(wheel_file)
 
         files_to_upload = [new_tar_ball, *new_tar_ball_signed, wheel_file, *wheel_signed_files]
-        return files_to_upload
+        # Return absolute paths: the caller (svn_upload) runs from the repo root,
+        # but these paths are relative to the package working_dir we chdir'd into.
+        return [os.path.abspath(f) for f in files_to_upload]
 
     finally:
         # Always return to original directory
@@ -474,10 +476,13 @@ def svn_upload(package_name: str, version, rc_num, files_to_import: list[str], a
 
     try:
         # Create a new directory for the release candidate.
+        # Tolerate an already-existing directory (e.g. re-running after a
+        # partial upload): mkdir failing because the path exists is not fatal,
+        # we still want to import the files below.
         print(
             f"Creating directory for {package_name} {version}-incubating-RC{rc_num}... at {svn_path}"
         )
-        subprocess.run(
+        mkdir_result = subprocess.run(
             [
                 "svn",
                 "mkdir",
@@ -486,8 +491,15 @@ def svn_upload(package_name: str, version, rc_num, files_to_import: list[str], a
                 f"Creating directory for {package_name} {version}-incubating-RC{rc_num}",
                 svn_path,
             ],
-            check=True,
+            capture_output=True,
+            text=True,
         )
+        if mkdir_result.returncode != 0:
+            if "already exists" in (mkdir_result.stderr or ""):
+                print(f"Directory already exists at {svn_path}, continuing to import files.")
+            else:
+                print(f"Error creating SVN directory: {mkdir_result.stderr.strip()}")
+                return None
 
         # Use svn import for the new directory.
         for file_path in files_to_import:

--- a/scripts/verify-sub-packages/verify_contrib.sh
+++ b/scripts/verify-sub-packages/verify_contrib.sh
@@ -59,6 +59,10 @@ if [ -z "$ARTIFACTS_DIR" ]; then
     svn export -q "https://dist.apache.org/repos/dist/dev/incubator/hamilton/${PACKAGE}/${VERSION}-RC${RC}/" "$ARTIFACTS_DIR"
 fi
 
+# Resolve to an absolute path: later steps cd into /tmp, which would break
+# a relative artifacts dir.
+ARTIFACTS_DIR="$(cd "$ARTIFACTS_DIR" && pwd)"
+
 echo "Artifacts: $ARTIFACTS_DIR"
 ls "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl 2>/dev/null || { echo "ERROR: No artifacts found"; exit 1; }
 

--- a/scripts/verify-sub-packages/verify_lsp.sh
+++ b/scripts/verify-sub-packages/verify_lsp.sh
@@ -59,6 +59,10 @@ if [ -z "$ARTIFACTS_DIR" ]; then
     svn export -q "https://dist.apache.org/repos/dist/dev/incubator/hamilton/${PACKAGE}/${VERSION}-RC${RC}/" "$ARTIFACTS_DIR"
 fi
 
+# Resolve to an absolute path: later steps cd into /tmp, which would break
+# a relative artifacts dir.
+ARTIFACTS_DIR="$(cd "$ARTIFACTS_DIR" && pwd)"
+
 echo "Artifacts: $ARTIFACTS_DIR"
 ls "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl 2>/dev/null || { echo "ERROR: No artifacts found"; exit 1; }
 

--- a/scripts/verify-sub-packages/verify_sdk.sh
+++ b/scripts/verify-sub-packages/verify_sdk.sh
@@ -59,6 +59,10 @@ if [ -z "$ARTIFACTS_DIR" ]; then
     svn export -q "https://dist.apache.org/repos/dist/dev/incubator/hamilton/${PACKAGE}/${VERSION}-RC${RC}/" "$ARTIFACTS_DIR"
 fi
 
+# Resolve to an absolute path: later steps cd into /tmp, which would break
+# a relative artifacts dir.
+ARTIFACTS_DIR="$(cd "$ARTIFACTS_DIR" && pwd)"
+
 echo "Artifacts: $ARTIFACTS_DIR"
 ls "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl 2>/dev/null || { echo "ERROR: No artifacts found"; exit 1; }
 

--- a/scripts/verify-sub-packages/verify_ui.sh
+++ b/scripts/verify-sub-packages/verify_ui.sh
@@ -59,6 +59,10 @@ if [ -z "$ARTIFACTS_DIR" ]; then
     svn export -q "https://dist.apache.org/repos/dist/dev/incubator/hamilton/${PACKAGE}/${VERSION}-RC${RC}/" "$ARTIFACTS_DIR"
 fi
 
+# Resolve to an absolute path: later steps cd into /tmp, which would break
+# a relative artifacts dir.
+ARTIFACTS_DIR="$(cd "$ARTIFACTS_DIR" && pwd)"
+
 echo "Artifacts: $ARTIFACTS_DIR"
 ls "$ARTIFACTS_DIR"/*.tar.gz "$ARTIFACTS_DIR"/*.whl 2>/dev/null || { echo "ERROR: No artifacts found"; exit 1; }
 


### PR DESCRIPTION
These bugs surfaced while cutting the apache-hamilton-{sdk,ui,lsp,contrib} RC1 release.

## `scripts/apache_release_helper.py`

**Absolute artifact paths.** `create_release_artifacts` chdir's into the package `working_dir` to build, but `svn_upload` runs from the repo root. The previously-returned **relative** paths then failed to resolve, producing:

```
svn: E000002: Can't stat '/Users/.../hamilton/dist/apache-hamilton-contrib-0.0.9-incubating-src.tar.gz': No such file or directory
```

Now returns absolute paths so the import works regardless of CWD.

**Resumable SVN upload.** `svn_upload` unconditionally ran `svn mkdir` with `check=True`. If a prior run partially uploaded (dir created, some files imported) a re-run aborted on `svn mkdir` ('directory already exists'). Now a pre-existing RC directory is tolerated so the re-run resumes importing the remaining files. (This is exactly what happened with contrib RC1, which uploaded only 2 of 6 files.)

## `scripts/verify-sub-packages/*.sh` (all 4)

The functional-verification step does `cd /tmp` (so the local hamilton checkout doesn't shadow venv-installed packages via `''` on `sys.path`), but then referenced `$ARTIFACTS_DIR` relatively — breaking when a relative local artifacts dir was passed (e.g. `verify_sdk.sh 0.9.0 1 ui/sdk/dist`):

```
error: Distribution not found at: file:///private/tmp/ui/sdk/dist/apache_hamilton_sdk-...whl
```

Now `ARTIFACTS_DIR` is resolved to an absolute path right after acquisition.

## Verification
All four verify scripts were re-run end-to-end against the live SVN RC1 artifacts after these fixes and passed (GPG, SHA512, RAT, build-from-source, functional).