### PR TITLE
Fix collect visualization edge styling

### DIFF
--- a/hamilton/graph.py
+++ b/hamilton/graph.py
@@ -437,6 +437,13 @@ def create_graphviz_graph(
 
         return edge_style
 
+    def _is_collect_dependency_edge(dependency_node: node.Node, target_node: node.Node) -> bool:
+        """Returns true for the edge that feeds a Collect[...] dependency."""
+        return (
+            target_node.node_role == node.NodeType.COLLECT
+            and dependency_node.name == target_node.collect_dependency
+        )
+
     def _get_legend(
         node_types: set[str], extra_legend_nodes: dict[tuple[str, str], dict[str, str]]
     ):
@@ -648,7 +655,6 @@ def create_graphviz_graph(
     # create edges
     input_sets = dict()
     for n in nodes:
-        to_type = "collect" if n.node_role == node.NodeType.COLLECT else ""
         to_modifiers = node_modifiers.get(n.name, set())
 
         input_nodes = set()
@@ -664,6 +670,7 @@ def create_graphviz_graph(
                 continue
 
             from_type = "expand" if d.node_role == node.NodeType.EXPAND else ""
+            to_type = "collect" if _is_collect_dependency_edge(d, n) else ""
             dependency_modifiers = node_modifiers.get(d.name, set())
             edge_style = _get_edge_style(from_type, to_type)
             if (

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -42,6 +42,7 @@ import tests.resources.display_name_functions
 import tests.resources.display_name_list_functions
 import tests.resources.dummy_functions
 import tests.resources.dummy_functions_module_override
+import tests.resources.dynamic_parallelism.parallel_collect_multiple_arguments
 import tests.resources.extract_column_nodes
 import tests.resources.extract_columns_execution_count
 import tests.resources.functions_with_generics
@@ -1196,6 +1197,32 @@ def test_function_graph_display_config_node():
 
     # lines start tab then node name; check if "b" is a node in the graphviz object
     assert any(line.startswith("\tX") for line in dot.body)
+
+
+def test_function_graph_display_collect_edges_only_style_collected_dependency():
+    config = {}
+    fg = graph.FunctionGraph.from_modules(
+        tests.resources.dynamic_parallelism.parallel_collect_multiple_arguments, config=config
+    )
+
+    assert fg.nodes["summed"].node_role == NodeType.COLLECT
+    assert fg.nodes["summed"].collect_dependency == "double"
+
+    dot = fg.display(set(fg.get_nodes()), output_file_path=None, config=config)
+
+    edge_lines = {
+        line.strip().split(" [", 1)[0]: line.strip() for line in dot.body if " -> " in line
+    }
+    assert edge_lines["double -> summed"] == "double -> summed [arrowtail=crow dir=both]"
+    assert edge_lines["not_to_repeat -> summed"] == "not_to_repeat -> summed"
+    assert (
+        edge_lines["something_else_not_to_repeat -> summed"]
+        == "something_else_not_to_repeat -> summed"
+    )
+    assert (
+        edge_lines["number_to_repeat -> double"]
+        == "number_to_repeat -> double [arrowhead=crow arrowtail=none dir=both]"
+    )
 
 
 # TODO use high-level visualization dot as fixtures for reuse across tests


### PR DESCRIPTION
Fixes #556

This narrows collect edge styling in graph visualization so only the dependency annotated as `Collect[...]` is drawn with the collect crow-foot. Ordinary scalar inputs into the same collect node remain normal edges.

## Changes

- Apply collect edge styling only when the edge feeds the target node's actual `Collect[...]` dependency.
- Keep collect node styling and expand edge styling unchanged.
- Add a regression test for the multi-argument collect visualization case.

## How I tested this

- `MPLCONFIGDIR=.mplconfig XDG_CACHE_HOME=.cache UV_CACHE_DIR=.uv-cache ./.uv-tools/bin/uv run pytest tests/test_graph.py -q`
- `UV_CACHE_DIR=.uv-cache ./.uv-tools/bin/uv run ruff check hamilton/graph.py tests/test_graph.py`
- `UV_CACHE_DIR=.uv-cache ./.uv-tools/bin/uv run ruff format --check hamilton/graph.py tests/test_graph.py`
- `git diff --check`

## Notes

This is limited to visualization edge styling. It does not change dynamic execution or grouping semantics.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the focused checks listed above & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
