### PR TITLE
Fix issue 791: add LazyFrame sink classes for parquet, csv, ipc, ndjson

### DIFF
--- a/hamilton/plugins/polars_lazyframe_extensions.py
+++ b/hamilton/plugins/polars_lazyframe_extensions.py
@@ -47,7 +47,7 @@ from polars.datatypes import DataType, DataTypeClass  # noqa: F401
 
 from hamilton import registry
 from hamilton.io import utils
-from hamilton.io.data_adapters import DataLoader
+from hamilton.io.data_adapters import DataLoader, DataSaver
 
 DATAFRAME_TYPE = pl.LazyFrame
 COLUMN_TYPE = pl.Expr
@@ -288,6 +288,85 @@ class PolarsScanFeatherReader(DataLoader):
     def name(cls) -> str:
         return "feather"
 
+@dataclasses.dataclass
+class PolarsLazyFrameSinkParquet(DataSaver):
+    """Class to handle sinking a Polars LazyFrame to a Parquet file.
+    Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_parquet.html
+    """
+    path: str | Path
+
+    @classmethod
+    def applicable_types(cls) -> Collection[type]:
+        return [DATAFRAME_TYPE]
+
+    def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
+        data.sink_parquet(self.path)
+        return utils.get_file_metadata(self.path)
+
+    @classmethod
+    def name(cls) -> str:
+        return "parquet"
+
+
+@dataclasses.dataclass
+class PolarsLazyFrameSinkCSV(DataSaver):
+    """Class to handle sinking a Polars LazyFrame to a CSV file.
+    Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_csv.html
+    """
+    path: str | Path
+
+    @classmethod
+    def applicable_types(cls) -> Collection[type]:
+        return [DATAFRAME_TYPE]
+
+    def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
+        data.sink_csv(self.path)
+        return utils.get_file_metadata(self.path)
+
+    @classmethod
+    def name(cls) -> str:
+        return "csv"
+
+
+@dataclasses.dataclass
+class PolarsLazyFrameSinkIPC(DataSaver):
+    """Class to handle sinking a Polars LazyFrame to an IPC/Feather file.
+    Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_ipc.html
+    """
+    path: str | Path
+
+    @classmethod
+    def applicable_types(cls) -> Collection[type]:
+        return [DATAFRAME_TYPE]
+
+    def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
+        data.sink_ipc(self.path)
+        return utils.get_file_metadata(self.path)
+
+    @classmethod
+    def name(cls) -> str:
+        return "ipc"
+
+
+@dataclasses.dataclass
+class PolarsLazyFrameSinkNDJSON(DataSaver):
+    """Class to handle sinking a Polars LazyFrame to an NDJSON file.
+    Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_ndjson.html
+    """
+    path: str | Path
+
+    @classmethod
+    def applicable_types(cls) -> Collection[type]:
+        return [DATAFRAME_TYPE]
+
+    def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
+        data.sink_ndjson(self.path)
+        return utils.get_file_metadata(self.path)
+
+    @classmethod
+    def name(cls) -> str:
+        return "ndjson"
+
 
 def register_data_loaders():
     """Function to register the data loaders for this extension."""
@@ -295,6 +374,10 @@ def register_data_loaders():
         PolarsScanCSVReader,
         PolarsScanParquetReader,
         PolarsScanFeatherReader,
+        PolarsLazyFrameSinkParquet,
+        PolarsLazyFrameSinkCSV,
+        PolarsLazyFrameSinkIPC,
+        PolarsLazyFrameSinkNDJSON,
     ]:
         registry.register_adapter(loader)
 

--- a/hamilton/plugins/polars_lazyframe_extensions.py
+++ b/hamilton/plugins/polars_lazyframe_extensions.py
@@ -287,20 +287,46 @@ class PolarsScanFeatherReader(DataLoader):
     @classmethod
     def name(cls) -> str:
         return "feather"
+    
+
+####
 
 @dataclasses.dataclass
-class PolarsLazyFrameSinkParquet(DataSaver):
+class PolarsSinkParquetWriter(DataSaver):
     """Class to handle sinking a Polars LazyFrame to a Parquet file.
     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_parquet.html
     """
     path: str | Path
+    # kwargs:
+    compression: str = "zstd"
+    compression_level: int | None = None
+    statistics: bool = True
+    row_group_size: int | None = None
+    data_page_size: int | None = None
+    maintain_order: bool = True
+
+    def _get_saving_kwargs(self):
+        kwargs = {}
+        if self.compression is not None:
+            kwargs["compression"] = self.compression
+        if self.compression_level is not None:
+            kwargs["compression_level"] = self.compression_level
+        if self.statistics is not None:
+            kwargs["statistics"] = self.statistics
+        if self.row_group_size is not None:
+            kwargs["row_group_size"] = self.row_group_size
+        if self.data_page_size is not None:
+            kwargs["data_page_size"] = self.data_page_size
+        if self.maintain_order is not None:
+            kwargs["maintain_order"] = self.maintain_order
+        return kwargs
 
     @classmethod
     def applicable_types(cls) -> Collection[type]:
         return [DATAFRAME_TYPE]
 
     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-        data.sink_parquet(self.path)
+        data.sink_parquet(self.path, **self._get_saving_kwargs())
         return utils.get_file_metadata(self.path)
 
     @classmethod
@@ -309,18 +335,59 @@ class PolarsLazyFrameSinkParquet(DataSaver):
 
 
 @dataclasses.dataclass
-class PolarsLazyFrameSinkCSV(DataSaver):
+class PolarsSinkCSVWriter(DataSaver):
     """Class to handle sinking a Polars LazyFrame to a CSV file.
     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_csv.html
     """
     path: str | Path
+    # kwargs:
+    separator: str = ","
+    line_terminator: str = "\n"
+    quote_char: str = '"'
+    batch_size: int = 1024
+    datetime_format: str | None = None
+    date_format: str | None = None
+    time_format: str | None = None
+    float_scientific: bool | None = None
+    float_precision: int | None = None
+    null_value: str = ""
+    quote_style: str = "necessary"
+    maintain_order: bool = True
+
+    def _get_saving_kwargs(self):
+        kwargs = {}
+        if self.separator is not None:
+            kwargs["separator"] = self.separator
+        if self.line_terminator is not None:
+            kwargs["line_terminator"] = self.line_terminator
+        if self.quote_char is not None:
+            kwargs["quote_char"] = self.quote_char
+        if self.batch_size is not None:
+            kwargs["batch_size"] = self.batch_size
+        if self.datetime_format is not None:
+            kwargs["datetime_format"] = self.datetime_format
+        if self.date_format is not None:
+            kwargs["date_format"] = self.date_format
+        if self.time_format is not None:
+            kwargs["time_format"] = self.time_format
+        if self.float_scientific is not None:
+            kwargs["float_scientific"] = self.float_scientific
+        if self.float_precision is not None:
+            kwargs["float_precision"] = self.float_precision
+        if self.null_value is not None:
+            kwargs["null_value"] = self.null_value
+        if self.quote_style is not None:
+            kwargs["quote_style"] = self.quote_style
+        if self.maintain_order is not None:
+            kwargs["maintain_order"] = self.maintain_order
+        return kwargs
 
     @classmethod
     def applicable_types(cls) -> Collection[type]:
         return [DATAFRAME_TYPE]
 
     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-        data.sink_csv(self.path)
+        data.sink_csv(self.path, **self._get_saving_kwargs())
         return utils.get_file_metadata(self.path)
 
     @classmethod
@@ -329,18 +396,29 @@ class PolarsLazyFrameSinkCSV(DataSaver):
 
 
 @dataclasses.dataclass
-class PolarsLazyFrameSinkIPC(DataSaver):
+class PolarsSinkFeatherWriter(DataSaver):
     """Class to handle sinking a Polars LazyFrame to an IPC/Feather file.
     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_ipc.html
     """
     path: str | Path
+    # kwargs:
+    compression: str = "uncompressed"
+    maintain_order: bool = True
+
+    def _get_saving_kwargs(self):
+        kwargs = {}
+        if self.compression is not None:
+            kwargs["compression"] = self.compression
+        if self.maintain_order is not None:
+            kwargs["maintain_order"] = self.maintain_order
+        return kwargs
 
     @classmethod
     def applicable_types(cls) -> Collection[type]:
         return [DATAFRAME_TYPE]
 
     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-        data.sink_ipc(self.path)
+        data.sink_ipc(self.path, **self._get_saving_kwargs())
         return utils.get_file_metadata(self.path)
 
     @classmethod
@@ -349,18 +427,26 @@ class PolarsLazyFrameSinkIPC(DataSaver):
 
 
 @dataclasses.dataclass
-class PolarsLazyFrameSinkNDJSON(DataSaver):
+class PolarsSinkNDJSONWriter(DataSaver):
     """Class to handle sinking a Polars LazyFrame to an NDJSON file.
     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_ndjson.html
     """
     path: str | Path
+    # kwargs:
+    maintain_order: bool = True
+
+    def _get_saving_kwargs(self):
+        kwargs = {}
+        if self.maintain_order is not None:
+            kwargs["maintain_order"] = self.maintain_order
+        return kwargs
 
     @classmethod
     def applicable_types(cls) -> Collection[type]:
         return [DATAFRAME_TYPE]
 
     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-        data.sink_ndjson(self.path)
+        data.sink_ndjson(self.path, **self._get_saving_kwargs())
         return utils.get_file_metadata(self.path)
 
     @classmethod
@@ -374,12 +460,108 @@ def register_data_loaders():
         PolarsScanCSVReader,
         PolarsScanParquetReader,
         PolarsScanFeatherReader,
-        PolarsLazyFrameSinkParquet,
-        PolarsLazyFrameSinkCSV,
-        PolarsLazyFrameSinkIPC,
-        PolarsLazyFrameSinkNDJSON,
+        PolarsSinkParquetWriter,
+        PolarsSinkCSVWriter,
+        PolarsSinkFeatherWriter,
+        PolarsSinkNDJSONWriter,
     ]:
         registry.register_adapter(loader)
 
 
 register_data_loaders()
+
+# @dataclasses.dataclass
+# class PolarsLazyFrameSinkParquet(DataSaver):
+#     """Class to handle sinking a Polars LazyFrame to a Parquet file.
+#     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_parquet.html
+#     """
+#     path: str | Path
+
+#     @classmethod
+#     def applicable_types(cls) -> Collection[type]:
+#         return [DATAFRAME_TYPE]
+
+#     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
+#         data.sink_parquet(self.path)
+#         return utils.get_file_metadata(self.path)
+
+#     @classmethod
+#     def name(cls) -> str:
+#         return "parquet"
+
+
+# @dataclasses.dataclass
+# class PolarsLazyFrameSinkCSV(DataSaver):
+#     """Class to handle sinking a Polars LazyFrame to a CSV file.
+#     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_csv.html
+#     """
+#     path: str | Path
+
+#     @classmethod
+#     def applicable_types(cls) -> Collection[type]:
+#         return [DATAFRAME_TYPE]
+
+#     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
+#         data.sink_csv(self.path)
+#         return utils.get_file_metadata(self.path)
+
+#     @classmethod
+#     def name(cls) -> str:
+#         return "csv"
+
+
+# @dataclasses.dataclass
+# class PolarsLazyFrameSinkIPC(DataSaver):
+#     """Class to handle sinking a Polars LazyFrame to an IPC/Feather file.
+#     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_ipc.html
+#     """
+#     path: str | Path
+
+#     @classmethod
+#     def applicable_types(cls) -> Collection[type]:
+#         return [DATAFRAME_TYPE]
+
+#     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
+#         data.sink_ipc(self.path)
+#         return utils.get_file_metadata(self.path)
+
+#     @classmethod
+#     def name(cls) -> str:
+#         return "ipc"
+
+
+# @dataclasses.dataclass
+# class PolarsLazyFrameSinkNDJSON(DataSaver):
+#     """Class to handle sinking a Polars LazyFrame to an NDJSON file.
+#     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_ndjson.html
+#     """
+#     path: str | Path
+
+#     @classmethod
+#     def applicable_types(cls) -> Collection[type]:
+#         return [DATAFRAME_TYPE]
+
+#     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
+#         data.sink_ndjson(self.path)
+#         return utils.get_file_metadata(self.path)
+
+#     @classmethod
+#     def name(cls) -> str:
+#         return "ndjson"
+
+
+# def register_data_loaders():
+#     """Function to register the data loaders for this extension."""
+#     for loader in [
+#         PolarsScanCSVReader,
+#         PolarsScanParquetReader,
+#         PolarsScanFeatherReader,
+#         PolarsLazyFrameSinkParquet,
+#         PolarsLazyFrameSinkCSV,
+#         PolarsLazyFrameSinkIPC,
+#         PolarsLazyFrameSinkNDJSON,
+#     ]:
+#         registry.register_adapter(loader)
+
+
+# register_data_loaders()

--- a/hamilton/plugins/polars_lazyframe_extensions.py
+++ b/hamilton/plugins/polars_lazyframe_extensions.py
@@ -194,8 +194,12 @@ class PolarsSinkCSVWriter(DataSaver):
     the file to exist immediately after the call returns.
     """
 
-    path: str | Path
+    file: str | Path
     # kwargs:
+    include_bom: bool | None = None
+    compression: str | None = None
+    compression_level: int | None = None
+    check_extension: bool | None = None
     include_header: bool = True
     separator: str = ","
     line_terminator: str = "\n"
@@ -206,12 +210,29 @@ class PolarsSinkCSVWriter(DataSaver):
     time_format: str | None = None
     float_scientific: bool | None = None
     float_precision: int | None = None
-    null_value: str = ""
-    quote_style: str = "necessary"
+    decimal_comma: bool | None = None
+    null_value: str | None = None
+    quote_style: Any = None
     maintain_order: bool = True
+    storage_options: dict[str, Any] | None = None
+    credential_provider: Any = None
+    retries: int | None = None
+    sync_on_close: Any = None
+    mkdir: bool | None = None
+    engine: Any = None
+    optimizations: Any = None
+    extra_kwargs: dict[str, Any] | None = None
 
-    def _get_saving_kwargs(self):
+    def _get_saving_kwargs(self) -> dict[str, Any]:
         kwargs = {}
+        if self.include_bom is not None:
+            kwargs["include_bom"] = self.include_bom
+        if self.compression is not None:
+            kwargs["compression"] = self.compression
+        if self.compression_level is not None:
+            kwargs["compression_level"] = self.compression_level
+        if self.check_extension is not None:
+            kwargs["check_extension"] = self.check_extension
         if self.include_header is not None:
             kwargs["include_header"] = self.include_header
         if self.separator is not None:
@@ -232,12 +253,30 @@ class PolarsSinkCSVWriter(DataSaver):
             kwargs["float_scientific"] = self.float_scientific
         if self.float_precision is not None:
             kwargs["float_precision"] = self.float_precision
+        if self.decimal_comma is not None:
+            kwargs["decimal_comma"] = self.decimal_comma
         if self.null_value is not None:
             kwargs["null_value"] = self.null_value
         if self.quote_style is not None:
             kwargs["quote_style"] = self.quote_style
         if self.maintain_order is not None:
             kwargs["maintain_order"] = self.maintain_order
+        if self.storage_options is not None:
+            kwargs["storage_options"] = self.storage_options
+        if self.credential_provider is not None:
+            kwargs["credential_provider"] = self.credential_provider
+        if self.retries is not None:
+            kwargs["retries"] = self.retries
+        if self.sync_on_close is not None:
+            kwargs["sync_on_close"] = self.sync_on_close
+        if self.mkdir is not None:
+            kwargs["mkdir"] = self.mkdir
+        if self.engine is not None:
+            kwargs["engine"] = self.engine
+        if self.optimizations is not None:
+            kwargs["optimizations"] = self.optimizations
+        if self.extra_kwargs is not None:
+            kwargs.update(self.extra_kwargs)
         return kwargs
 
     @classmethod
@@ -245,8 +284,8 @@ class PolarsSinkCSVWriter(DataSaver):
         return [DATAFRAME_TYPE]
 
     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-        data.sink_csv(self.path, **self._get_saving_kwargs())
-        return utils.get_file_metadata(self.path)
+        data.sink_csv(self.file, **self._get_saving_kwargs())
+        return utils.get_file_metadata(self.file)
 
     @classmethod
     def name(cls) -> str:
@@ -320,16 +359,26 @@ class PolarsSinkParquetWriter(DataSaver):
     the file to exist immediately after the call returns.
     """
 
-    path: str | Path
+    file: str | Path
     # kwargs:
     compression: str = "zstd"
     compression_level: int | None = None
-    statistics: bool = True
+    statistics: bool | str | dict[str, bool] = True
     row_group_size: int | None = None
     data_page_size: int | None = None
     maintain_order: bool = True
+    storage_options: dict[str, Any] | None = None
+    credential_provider: Any = None
+    retries: int | None = None
+    sync_on_close: Any = None
+    metadata: Any = None
+    arrow_schema: Any = None
+    mkdir: bool | None = None
+    engine: Any = None
+    optimizations: Any = None
+    extra_kwargs: dict[str, Any] | None = None
 
-    def _get_saving_kwargs(self):
+    def _get_saving_kwargs(self) -> dict[str, Any]:
         kwargs = {}
         if self.compression is not None:
             kwargs["compression"] = self.compression
@@ -343,6 +392,26 @@ class PolarsSinkParquetWriter(DataSaver):
             kwargs["data_page_size"] = self.data_page_size
         if self.maintain_order is not None:
             kwargs["maintain_order"] = self.maintain_order
+        if self.storage_options is not None:
+            kwargs["storage_options"] = self.storage_options
+        if self.credential_provider is not None:
+            kwargs["credential_provider"] = self.credential_provider
+        if self.retries is not None:
+            kwargs["retries"] = self.retries
+        if self.sync_on_close is not None:
+            kwargs["sync_on_close"] = self.sync_on_close
+        if self.metadata is not None:
+            kwargs["metadata"] = self.metadata
+        if self.arrow_schema is not None:
+            kwargs["arrow_schema"] = self.arrow_schema
+        if self.mkdir is not None:
+            kwargs["mkdir"] = self.mkdir
+        if self.engine is not None:
+            kwargs["engine"] = self.engine
+        if self.optimizations is not None:
+            kwargs["optimizations"] = self.optimizations
+        if self.extra_kwargs is not None:
+            kwargs.update(self.extra_kwargs)
         return kwargs
 
     @classmethod
@@ -350,8 +419,8 @@ class PolarsSinkParquetWriter(DataSaver):
         return [DATAFRAME_TYPE]
 
     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-        data.sink_parquet(self.path, **self._get_saving_kwargs())
-        return utils.get_file_metadata(self.path)
+        data.sink_parquet(self.file, **self._get_saving_kwargs())
+        return utils.get_file_metadata(self.file)
 
     @classmethod
     def name(cls) -> str:
@@ -419,17 +488,47 @@ class PolarsSinkFeatherWriter(DataSaver):
     the file to exist immediately after the call returns.
     """
 
-    path: str | Path
+    file: str | Path
     # kwargs:
     compression: str = "uncompressed"
+    compat_level: Any = None
+    record_batch_size: int | None = None
     maintain_order: bool = True
+    storage_options: dict[str, Any] | None = None
+    credential_provider: Any = None
+    retries: int | None = None
+    sync_on_close: Any = None
+    mkdir: bool | None = None
+    engine: Any = None
+    optimizations: Any = None
+    extra_kwargs: dict[str, Any] | None = None
 
-    def _get_saving_kwargs(self):
+    def _get_saving_kwargs(self) -> dict[str, Any]:
         kwargs = {}
         if self.compression is not None:
             kwargs["compression"] = self.compression
+        if self.compat_level is not None:
+            kwargs["compat_level"] = self.compat_level
+        if self.record_batch_size is not None:
+            kwargs["record_batch_size"] = self.record_batch_size
         if self.maintain_order is not None:
             kwargs["maintain_order"] = self.maintain_order
+        if self.storage_options is not None:
+            kwargs["storage_options"] = self.storage_options
+        if self.credential_provider is not None:
+            kwargs["credential_provider"] = self.credential_provider
+        if self.retries is not None:
+            kwargs["retries"] = self.retries
+        if self.sync_on_close is not None:
+            kwargs["sync_on_close"] = self.sync_on_close
+        if self.mkdir is not None:
+            kwargs["mkdir"] = self.mkdir
+        if self.engine is not None:
+            kwargs["engine"] = self.engine
+        if self.optimizations is not None:
+            kwargs["optimizations"] = self.optimizations
+        if self.extra_kwargs is not None:
+            kwargs.update(self.extra_kwargs)
         return kwargs
 
     @classmethod
@@ -437,8 +536,8 @@ class PolarsSinkFeatherWriter(DataSaver):
         return [DATAFRAME_TYPE]
 
     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-        data.sink_ipc(self.path, **self._get_saving_kwargs())
-        return utils.get_file_metadata(self.path)
+        data.sink_ipc(self.file, **self._get_saving_kwargs())
+        return utils.get_file_metadata(self.file)
 
     @classmethod
     def name(cls) -> str:
@@ -456,14 +555,47 @@ class PolarsSinkNDJSONWriter(DataSaver):
     the file to exist immediately after the call returns.
     """
 
-    path: str | Path
+    file: str | Path
     # kwargs:
+    compression: str | None = None
+    compression_level: int | None = None
+    check_extension: bool | None = None
     maintain_order: bool = True
+    storage_options: dict[str, Any] | None = None
+    credential_provider: Any = None
+    retries: int | None = None
+    sync_on_close: Any = None
+    mkdir: bool | None = None
+    engine: Any = None
+    optimizations: Any = None
+    extra_kwargs: dict[str, Any] | None = None
 
-    def _get_saving_kwargs(self):
+    def _get_saving_kwargs(self) -> dict[str, Any]:
         kwargs = {}
+        if self.compression is not None:
+            kwargs["compression"] = self.compression
+        if self.compression_level is not None:
+            kwargs["compression_level"] = self.compression_level
+        if self.check_extension is not None:
+            kwargs["check_extension"] = self.check_extension
         if self.maintain_order is not None:
             kwargs["maintain_order"] = self.maintain_order
+        if self.storage_options is not None:
+            kwargs["storage_options"] = self.storage_options
+        if self.credential_provider is not None:
+            kwargs["credential_provider"] = self.credential_provider
+        if self.retries is not None:
+            kwargs["retries"] = self.retries
+        if self.sync_on_close is not None:
+            kwargs["sync_on_close"] = self.sync_on_close
+        if self.mkdir is not None:
+            kwargs["mkdir"] = self.mkdir
+        if self.engine is not None:
+            kwargs["engine"] = self.engine
+        if self.optimizations is not None:
+            kwargs["optimizations"] = self.optimizations
+        if self.extra_kwargs is not None:
+            kwargs.update(self.extra_kwargs)
         return kwargs
 
     @classmethod
@@ -471,8 +603,8 @@ class PolarsSinkNDJSONWriter(DataSaver):
         return [DATAFRAME_TYPE]
 
     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-        data.sink_ndjson(self.path, **self._get_saving_kwargs())
-        return utils.get_file_metadata(self.path)
+        data.sink_ndjson(self.file, **self._get_saving_kwargs())
+        return utils.get_file_metadata(self.file)
 
     @classmethod
     def name(cls) -> str:

--- a/hamilton/plugins/polars_lazyframe_extensions.py
+++ b/hamilton/plugins/polars_lazyframe_extensions.py
@@ -184,6 +184,76 @@ class PolarsScanCSVReader(DataLoader):
 
 
 @dataclasses.dataclass
+class PolarsSinkCSVWriter(DataSaver):
+    """Class to handle sinking a Polars LazyFrame to a CSV file using streaming.
+
+    Calls LazyFrame.sink_csv() directly, avoiding collect() for better performance.
+    Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_csv.html
+
+    Note: ``lazy=True`` is intentionally excluded because ``save_data()`` expects
+    the file to exist immediately after the call returns.
+    """
+
+    path: str | Path
+    # kwargs:
+    include_header: bool = True
+    separator: str = ","
+    line_terminator: str = "\n"
+    quote_char: str = '"'
+    batch_size: int = 1024
+    datetime_format: str | None = None
+    date_format: str | None = None
+    time_format: str | None = None
+    float_scientific: bool | None = None
+    float_precision: int | None = None
+    null_value: str = ""
+    quote_style: str = "necessary"
+    maintain_order: bool = True
+
+    def _get_saving_kwargs(self):
+        kwargs = {}
+        if self.include_header is not None:
+            kwargs["include_header"] = self.include_header
+        if self.separator is not None:
+            kwargs["separator"] = self.separator
+        if self.line_terminator is not None:
+            kwargs["line_terminator"] = self.line_terminator
+        if self.quote_char is not None:
+            kwargs["quote_char"] = self.quote_char
+        if self.batch_size is not None:
+            kwargs["batch_size"] = self.batch_size
+        if self.datetime_format is not None:
+            kwargs["datetime_format"] = self.datetime_format
+        if self.date_format is not None:
+            kwargs["date_format"] = self.date_format
+        if self.time_format is not None:
+            kwargs["time_format"] = self.time_format
+        if self.float_scientific is not None:
+            kwargs["float_scientific"] = self.float_scientific
+        if self.float_precision is not None:
+            kwargs["float_precision"] = self.float_precision
+        if self.null_value is not None:
+            kwargs["null_value"] = self.null_value
+        if self.quote_style is not None:
+            kwargs["quote_style"] = self.quote_style
+        if self.maintain_order is not None:
+            kwargs["maintain_order"] = self.maintain_order
+        return kwargs
+
+    @classmethod
+    def applicable_types(cls) -> Collection[type]:
+        return [DATAFRAME_TYPE]
+
+    def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
+        data.sink_csv(self.path, **self._get_saving_kwargs())
+        return utils.get_file_metadata(self.path)
+
+    @classmethod
+    def name(cls) -> str:
+        return "csv"
+
+
+@dataclasses.dataclass
 class PolarsScanParquetReader(DataLoader):
     """Class specifically to handle loading parquet files with polars
     Should map to https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.read_parquet.html
@@ -240,6 +310,55 @@ class PolarsScanParquetReader(DataLoader):
 
 
 @dataclasses.dataclass
+class PolarsSinkParquetWriter(DataSaver):
+    """Class to handle sinking a Polars LazyFrame to a Parquet file using streaming.
+
+    Calls LazyFrame.sink_parquet() directly, avoiding collect() for better performance.
+    Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_parquet.html
+
+    Note: ``lazy=True`` is intentionally excluded because ``save_data()`` expects
+    the file to exist immediately after the call returns.
+    """
+
+    path: str | Path
+    # kwargs:
+    compression: str = "zstd"
+    compression_level: int | None = None
+    statistics: bool = True
+    row_group_size: int | None = None
+    data_page_size: int | None = None
+    maintain_order: bool = True
+
+    def _get_saving_kwargs(self):
+        kwargs = {}
+        if self.compression is not None:
+            kwargs["compression"] = self.compression
+        if self.compression_level is not None:
+            kwargs["compression_level"] = self.compression_level
+        if self.statistics is not None:
+            kwargs["statistics"] = self.statistics
+        if self.row_group_size is not None:
+            kwargs["row_group_size"] = self.row_group_size
+        if self.data_page_size is not None:
+            kwargs["data_page_size"] = self.data_page_size
+        if self.maintain_order is not None:
+            kwargs["maintain_order"] = self.maintain_order
+        return kwargs
+
+    @classmethod
+    def applicable_types(cls) -> Collection[type]:
+        return [DATAFRAME_TYPE]
+
+    def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
+        data.sink_parquet(self.path, **self._get_saving_kwargs())
+        return utils.get_file_metadata(self.path)
+
+    @classmethod
+    def name(cls) -> str:
+        return "parquet"
+
+
+@dataclasses.dataclass
 class PolarsScanFeatherReader(DataLoader):
     """
     Class specifically to handle loading Feather/Arrow IPC files with Polars.
@@ -287,119 +406,19 @@ class PolarsScanFeatherReader(DataLoader):
     @classmethod
     def name(cls) -> str:
         return "feather"
-    
-
-####
-
-@dataclasses.dataclass
-class PolarsSinkParquetWriter(DataSaver):
-    """Class to handle sinking a Polars LazyFrame to a Parquet file.
-    Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_parquet.html
-    """
-    path: str | Path
-    # kwargs:
-    compression: str = "zstd"
-    compression_level: int | None = None
-    statistics: bool = True
-    row_group_size: int | None = None
-    data_page_size: int | None = None
-    maintain_order: bool = True
-
-    def _get_saving_kwargs(self):
-        kwargs = {}
-        if self.compression is not None:
-            kwargs["compression"] = self.compression
-        if self.compression_level is not None:
-            kwargs["compression_level"] = self.compression_level
-        if self.statistics is not None:
-            kwargs["statistics"] = self.statistics
-        if self.row_group_size is not None:
-            kwargs["row_group_size"] = self.row_group_size
-        if self.data_page_size is not None:
-            kwargs["data_page_size"] = self.data_page_size
-        if self.maintain_order is not None:
-            kwargs["maintain_order"] = self.maintain_order
-        return kwargs
-
-    @classmethod
-    def applicable_types(cls) -> Collection[type]:
-        return [DATAFRAME_TYPE]
-
-    def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-        data.sink_parquet(self.path, **self._get_saving_kwargs())
-        return utils.get_file_metadata(self.path)
-
-    @classmethod
-    def name(cls) -> str:
-        return "parquet"
-
-
-@dataclasses.dataclass
-class PolarsSinkCSVWriter(DataSaver):
-    """Class to handle sinking a Polars LazyFrame to a CSV file.
-    Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_csv.html
-    """
-    path: str | Path
-    # kwargs:
-    separator: str = ","
-    line_terminator: str = "\n"
-    quote_char: str = '"'
-    batch_size: int = 1024
-    datetime_format: str | None = None
-    date_format: str | None = None
-    time_format: str | None = None
-    float_scientific: bool | None = None
-    float_precision: int | None = None
-    null_value: str = ""
-    quote_style: str = "necessary"
-    maintain_order: bool = True
-
-    def _get_saving_kwargs(self):
-        kwargs = {}
-        if self.separator is not None:
-            kwargs["separator"] = self.separator
-        if self.line_terminator is not None:
-            kwargs["line_terminator"] = self.line_terminator
-        if self.quote_char is not None:
-            kwargs["quote_char"] = self.quote_char
-        if self.batch_size is not None:
-            kwargs["batch_size"] = self.batch_size
-        if self.datetime_format is not None:
-            kwargs["datetime_format"] = self.datetime_format
-        if self.date_format is not None:
-            kwargs["date_format"] = self.date_format
-        if self.time_format is not None:
-            kwargs["time_format"] = self.time_format
-        if self.float_scientific is not None:
-            kwargs["float_scientific"] = self.float_scientific
-        if self.float_precision is not None:
-            kwargs["float_precision"] = self.float_precision
-        if self.null_value is not None:
-            kwargs["null_value"] = self.null_value
-        if self.quote_style is not None:
-            kwargs["quote_style"] = self.quote_style
-        if self.maintain_order is not None:
-            kwargs["maintain_order"] = self.maintain_order
-        return kwargs
-
-    @classmethod
-    def applicable_types(cls) -> Collection[type]:
-        return [DATAFRAME_TYPE]
-
-    def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-        data.sink_csv(self.path, **self._get_saving_kwargs())
-        return utils.get_file_metadata(self.path)
-
-    @classmethod
-    def name(cls) -> str:
-        return "csv"
 
 
 @dataclasses.dataclass
 class PolarsSinkFeatherWriter(DataSaver):
-    """Class to handle sinking a Polars LazyFrame to an IPC/Feather file.
+    """Class to handle sinking a Polars LazyFrame to an IPC/Feather file using streaming.
+
+    Calls LazyFrame.sink_ipc() directly, avoiding collect() for better performance.
     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_ipc.html
+
+    Note: ``lazy=True`` is intentionally excluded because ``save_data()`` expects
+    the file to exist immediately after the call returns.
     """
+
     path: str | Path
     # kwargs:
     compression: str = "uncompressed"
@@ -423,14 +442,20 @@ class PolarsSinkFeatherWriter(DataSaver):
 
     @classmethod
     def name(cls) -> str:
-        return "ipc"
+        return "feather"
 
 
 @dataclasses.dataclass
 class PolarsSinkNDJSONWriter(DataSaver):
-    """Class to handle sinking a Polars LazyFrame to an NDJSON file.
+    """Class to handle sinking a Polars LazyFrame to an NDJSON file using streaming.
+
+    Calls LazyFrame.sink_ndjson() directly, avoiding collect() for better performance.
     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_ndjson.html
+
+    Note: ``lazy=True`` is intentionally excluded because ``save_data()`` expects
+    the file to exist immediately after the call returns.
     """
+
     path: str | Path
     # kwargs:
     maintain_order: bool = True
@@ -458,10 +483,10 @@ def register_data_loaders():
     """Function to register the data loaders for this extension."""
     for loader in [
         PolarsScanCSVReader,
-        PolarsScanParquetReader,
-        PolarsScanFeatherReader,
-        PolarsSinkParquetWriter,
         PolarsSinkCSVWriter,
+        PolarsScanParquetReader,
+        PolarsSinkParquetWriter,
+        PolarsScanFeatherReader,
         PolarsSinkFeatherWriter,
         PolarsSinkNDJSONWriter,
     ]:
@@ -469,99 +494,3 @@ def register_data_loaders():
 
 
 register_data_loaders()
-
-# @dataclasses.dataclass
-# class PolarsLazyFrameSinkParquet(DataSaver):
-#     """Class to handle sinking a Polars LazyFrame to a Parquet file.
-#     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_parquet.html
-#     """
-#     path: str | Path
-
-#     @classmethod
-#     def applicable_types(cls) -> Collection[type]:
-#         return [DATAFRAME_TYPE]
-
-#     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-#         data.sink_parquet(self.path)
-#         return utils.get_file_metadata(self.path)
-
-#     @classmethod
-#     def name(cls) -> str:
-#         return "parquet"
-
-
-# @dataclasses.dataclass
-# class PolarsLazyFrameSinkCSV(DataSaver):
-#     """Class to handle sinking a Polars LazyFrame to a CSV file.
-#     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_csv.html
-#     """
-#     path: str | Path
-
-#     @classmethod
-#     def applicable_types(cls) -> Collection[type]:
-#         return [DATAFRAME_TYPE]
-
-#     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-#         data.sink_csv(self.path)
-#         return utils.get_file_metadata(self.path)
-
-#     @classmethod
-#     def name(cls) -> str:
-#         return "csv"
-
-
-# @dataclasses.dataclass
-# class PolarsLazyFrameSinkIPC(DataSaver):
-#     """Class to handle sinking a Polars LazyFrame to an IPC/Feather file.
-#     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_ipc.html
-#     """
-#     path: str | Path
-
-#     @classmethod
-#     def applicable_types(cls) -> Collection[type]:
-#         return [DATAFRAME_TYPE]
-
-#     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-#         data.sink_ipc(self.path)
-#         return utils.get_file_metadata(self.path)
-
-#     @classmethod
-#     def name(cls) -> str:
-#         return "ipc"
-
-
-# @dataclasses.dataclass
-# class PolarsLazyFrameSinkNDJSON(DataSaver):
-#     """Class to handle sinking a Polars LazyFrame to an NDJSON file.
-#     Should map to https://docs.pola.rs/api/python/stable/reference/lazyframe/api/polars.LazyFrame.sink_ndjson.html
-#     """
-#     path: str | Path
-
-#     @classmethod
-#     def applicable_types(cls) -> Collection[type]:
-#         return [DATAFRAME_TYPE]
-
-#     def save_data(self, data: pl.LazyFrame) -> dict[str, Any]:
-#         data.sink_ndjson(self.path)
-#         return utils.get_file_metadata(self.path)
-
-#     @classmethod
-#     def name(cls) -> str:
-#         return "ndjson"
-
-
-# def register_data_loaders():
-#     """Function to register the data loaders for this extension."""
-#     for loader in [
-#         PolarsScanCSVReader,
-#         PolarsScanParquetReader,
-#         PolarsScanFeatherReader,
-#         PolarsLazyFrameSinkParquet,
-#         PolarsLazyFrameSinkCSV,
-#         PolarsLazyFrameSinkIPC,
-#         PolarsLazyFrameSinkNDJSON,
-#     ]:
-#         registry.register_adapter(loader)
-
-
-# register_data_loaders()

--- a/hamilton/plugins/polars_lazyframe_extensions.py
+++ b/hamilton/plugins/polars_lazyframe_extensions.py
@@ -276,6 +276,8 @@ class PolarsSinkCSVWriter(DataSaver):
         if self.optimizations is not None:
             kwargs["optimizations"] = self.optimizations
         if self.extra_kwargs is not None:
+            if self.extra_kwargs.get("lazy", False):
+                raise ValueError("lazy=True is incompatible with synchronous data savers.")
             kwargs.update(self.extra_kwargs)
         return kwargs
 
@@ -411,6 +413,8 @@ class PolarsSinkParquetWriter(DataSaver):
         if self.optimizations is not None:
             kwargs["optimizations"] = self.optimizations
         if self.extra_kwargs is not None:
+            if self.extra_kwargs.get("lazy", False):
+                raise ValueError("lazy=True is incompatible with synchronous data savers.")
             kwargs.update(self.extra_kwargs)
         return kwargs
 
@@ -490,7 +494,7 @@ class PolarsSinkFeatherWriter(DataSaver):
 
     file: str | Path
     # kwargs:
-    compression: str = "uncompressed"
+    compression: str | None = None
     compat_level: Any = None
     record_batch_size: int | None = None
     maintain_order: bool = True
@@ -528,6 +532,8 @@ class PolarsSinkFeatherWriter(DataSaver):
         if self.optimizations is not None:
             kwargs["optimizations"] = self.optimizations
         if self.extra_kwargs is not None:
+            if self.extra_kwargs.get("lazy", False):
+                raise ValueError("lazy=True is incompatible with synchronous data savers.")
             kwargs.update(self.extra_kwargs)
         return kwargs
 
@@ -595,6 +601,8 @@ class PolarsSinkNDJSONWriter(DataSaver):
         if self.optimizations is not None:
             kwargs["optimizations"] = self.optimizations
         if self.extra_kwargs is not None:
+            if self.extra_kwargs.get("lazy", False):
+                raise ValueError("lazy=True is incompatible with synchronous data savers.")
             kwargs.update(self.extra_kwargs)
         return kwargs
 

--- a/hamilton/plugins/polars_post_1_0_0_extensions.py
+++ b/hamilton/plugins/polars_post_1_0_0_extensions.py
@@ -197,7 +197,7 @@ class PolarsCSVWriter(DataSaver):
 
     @classmethod
     def applicable_types(cls) -> Collection[type]:
-        return [DATAFRAME_TYPE, pl.LazyFrame]
+        return [DATAFRAME_TYPE]
 
     def _get_saving_kwargs(self):
         kwargs = {}
@@ -227,9 +227,7 @@ class PolarsCSVWriter(DataSaver):
             kwargs["quote_style"] = self.quote_style
         return kwargs
 
-    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
-        if isinstance(data, pl.LazyFrame):
-            data = data.collect()
+    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
         data.write_csv(self.file, **self._get_saving_kwargs())
         return utils.get_file_and_dataframe_metadata(self.file, data)
 
@@ -318,7 +316,7 @@ class PolarsParquetWriter(DataSaver):
 
     @classmethod
     def applicable_types(cls) -> Collection[type]:
-        return [DATAFRAME_TYPE, pl.LazyFrame]
+        return [DATAFRAME_TYPE]
 
     def _get_saving_kwargs(self):
         kwargs = {}
@@ -336,10 +334,7 @@ class PolarsParquetWriter(DataSaver):
             kwargs["pyarrow_options"] = self.pyarrow_options
         return kwargs
 
-    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
-        if isinstance(data, pl.LazyFrame):
-            data = data.collect()
-
+    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
         data.write_parquet(self.file, **self._get_saving_kwargs())
 
         return utils.get_file_and_dataframe_metadata(self.file, data)
@@ -414,7 +409,7 @@ class PolarsFeatherWriter(DataSaver):
 
     @classmethod
     def applicable_types(cls) -> Collection[type]:
-        return [DATAFRAME_TYPE, pl.LazyFrame]
+        return [DATAFRAME_TYPE]
 
     def _get_saving_kwargs(self):
         kwargs = {}
@@ -422,9 +417,7 @@ class PolarsFeatherWriter(DataSaver):
             kwargs["compression"] = self.compression
         return kwargs
 
-    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
-        if isinstance(data, pl.LazyFrame):
-            data = data.collect()
+    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
         data.write_ipc(self.file, **self._get_saving_kwargs())
         return utils.get_file_and_dataframe_metadata(self.file, data)
 
@@ -600,12 +593,9 @@ class PolarsNDJSONWriter(DataSaver):
 
     @classmethod
     def applicable_types(cls) -> Collection[type]:
-        return [DATAFRAME_TYPE, pl.LazyFrame]
+        return [DATAFRAME_TYPE]
 
-    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
-        if isinstance(data, pl.LazyFrame):
-            data = data.collect()
-
+    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
         data.write_ndjson(self.file)
         return utils.get_file_and_dataframe_metadata(self.file, data)
 

--- a/hamilton/plugins/polars_post_1_0_0_extensions.py
+++ b/hamilton/plugins/polars_post_1_0_0_extensions.py
@@ -227,7 +227,9 @@ class PolarsCSVWriter(DataSaver):
             kwargs["quote_style"] = self.quote_style
         return kwargs
 
-    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
+    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
+        if isinstance(data, pl.LazyFrame):
+            data = data.collect()
         data.write_csv(self.file, **self._get_saving_kwargs())
         return utils.get_file_and_dataframe_metadata(self.file, data)
 
@@ -334,7 +336,9 @@ class PolarsParquetWriter(DataSaver):
             kwargs["pyarrow_options"] = self.pyarrow_options
         return kwargs
 
-    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
+    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
+        if isinstance(data, pl.LazyFrame):
+            data = data.collect()
         data.write_parquet(self.file, **self._get_saving_kwargs())
 
         return utils.get_file_and_dataframe_metadata(self.file, data)
@@ -417,7 +421,9 @@ class PolarsFeatherWriter(DataSaver):
             kwargs["compression"] = self.compression
         return kwargs
 
-    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
+    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
+        if isinstance(data, pl.LazyFrame):
+            data = data.collect()
         data.write_ipc(self.file, **self._get_saving_kwargs())
         return utils.get_file_and_dataframe_metadata(self.file, data)
 
@@ -595,7 +601,9 @@ class PolarsNDJSONWriter(DataSaver):
     def applicable_types(cls) -> Collection[type]:
         return [DATAFRAME_TYPE]
 
-    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
+    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
+        if isinstance(data, pl.LazyFrame):
+            data = data.collect()
         data.write_ndjson(self.file)
         return utils.get_file_and_dataframe_metadata(self.file, data)
 

--- a/hamilton/plugins/polars_pre_1_0_0_extension.py
+++ b/hamilton/plugins/polars_pre_1_0_0_extension.py
@@ -206,7 +206,7 @@ class PolarsCSVWriter(DataSaver):
 
     @classmethod
     def applicable_types(cls) -> Collection[type]:
-        return [DATAFRAME_TYPE, pl.LazyFrame]
+        return [DATAFRAME_TYPE]
 
     def _get_saving_kwargs(self):
         kwargs = {}
@@ -236,9 +236,7 @@ class PolarsCSVWriter(DataSaver):
             kwargs["quote_style"] = self.quote_style
         return kwargs
 
-    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
-        if isinstance(data, pl.LazyFrame):
-            data = data.collect()
+    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
         data.write_csv(self.file, **self._get_saving_kwargs())
         return utils.get_file_and_dataframe_metadata(self.file, data)
 
@@ -327,7 +325,7 @@ class PolarsParquetWriter(DataSaver):
 
     @classmethod
     def applicable_types(cls) -> Collection[type]:
-        return [DATAFRAME_TYPE, pl.LazyFrame]
+        return [DATAFRAME_TYPE]
 
     def _get_saving_kwargs(self):
         kwargs = {}
@@ -345,10 +343,7 @@ class PolarsParquetWriter(DataSaver):
             kwargs["pyarrow_options"] = self.pyarrow_options
         return kwargs
 
-    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
-        if isinstance(data, pl.LazyFrame):
-            data = data.collect()
-
+    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
         data.write_parquet(self.file, **self._get_saving_kwargs())
 
         return utils.get_file_and_dataframe_metadata(self.file, data)
@@ -423,7 +418,7 @@ class PolarsFeatherWriter(DataSaver):
 
     @classmethod
     def applicable_types(cls) -> Collection[type]:
-        return [DATAFRAME_TYPE, pl.LazyFrame]
+        return [DATAFRAME_TYPE]
 
     def _get_saving_kwargs(self):
         kwargs = {}
@@ -431,9 +426,7 @@ class PolarsFeatherWriter(DataSaver):
             kwargs["compression"] = self.compression
         return kwargs
 
-    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
-        if isinstance(data, pl.LazyFrame):
-            data = data.collect()
+    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
         data.write_ipc(self.file, **self._get_saving_kwargs())
         return utils.get_file_and_dataframe_metadata(self.file, data)
 

--- a/hamilton/plugins/polars_pre_1_0_0_extension.py
+++ b/hamilton/plugins/polars_pre_1_0_0_extension.py
@@ -44,9 +44,11 @@ if hasattr(pl, "type_aliases"):
 
 # for polars 0.18.0 we need to check what to do.
 if has_alias and hasattr(pl.type_aliases, "CsvEncoding"):
-    from polars.type_aliases import CsvEncoding, SchemaDefinition
+    from polars.type_aliases import CsvEncoding
+    SchemaDefinition = type
 else:
     CsvEncoding = type
+    SchemaDefinition = type
 if has_alias and hasattr(pl.type_aliases, "CsvQuoteStyle"):
     from polars.type_aliases import CsvQuoteStyle
 else:

--- a/hamilton/plugins/polars_pre_1_0_0_extension.py
+++ b/hamilton/plugins/polars_pre_1_0_0_extension.py
@@ -45,6 +45,7 @@ if hasattr(pl, "type_aliases"):
 # for polars 0.18.0 we need to check what to do.
 if has_alias and hasattr(pl.type_aliases, "CsvEncoding"):
     from polars.type_aliases import CsvEncoding
+
     SchemaDefinition = type
 else:
     CsvEncoding = type
@@ -238,7 +239,9 @@ class PolarsCSVWriter(DataSaver):
             kwargs["quote_style"] = self.quote_style
         return kwargs
 
-    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
+    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
+        if isinstance(data, pl.LazyFrame):
+            data = data.collect()
         data.write_csv(self.file, **self._get_saving_kwargs())
         return utils.get_file_and_dataframe_metadata(self.file, data)
 
@@ -345,7 +348,9 @@ class PolarsParquetWriter(DataSaver):
             kwargs["pyarrow_options"] = self.pyarrow_options
         return kwargs
 
-    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
+    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
+        if isinstance(data, pl.LazyFrame):
+            data = data.collect()
         data.write_parquet(self.file, **self._get_saving_kwargs())
 
         return utils.get_file_and_dataframe_metadata(self.file, data)
@@ -428,7 +433,9 @@ class PolarsFeatherWriter(DataSaver):
             kwargs["compression"] = self.compression
         return kwargs
 
-    def save_data(self, data: DATAFRAME_TYPE) -> dict[str, Any]:
+    def save_data(self, data: DATAFRAME_TYPE | pl.LazyFrame) -> dict[str, Any]:
+        if isinstance(data, pl.LazyFrame):
+            data = data.collect()
         data.write_ipc(self.file, **self._get_saving_kwargs())
         return utils.get_file_and_dataframe_metadata(self.file, data)
 

--- a/tests/plugins/test_polars_extensions.py
+++ b/tests/plugins/test_polars_extensions.py
@@ -67,7 +67,7 @@ def test_polars_csv(df: pl.DataFrame, tmp_path: pathlib.Path) -> None:
     kwargs2 = reader._get_loading_kwargs()
     df2, metadata = reader.load_data(pl.DataFrame)
 
-    assert PolarsCSVWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
+    assert PolarsCSVWriter.applicable_types() == [pl.DataFrame]
     assert PolarsCSVReader.applicable_types() == [pl.DataFrame]
     assert kwargs1["separator"] == ","
     assert kwargs2["has_header"] is True
@@ -85,7 +85,7 @@ def test_polars_parquet(df: pl.DataFrame, tmp_path: pathlib.Path) -> None:
     kwargs2 = reader._get_loading_kwargs()
     df2, metadata = reader.load_data(pl.DataFrame)
 
-    assert PolarsParquetWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
+    assert PolarsParquetWriter.applicable_types() == [pl.DataFrame]
     assert PolarsParquetReader.applicable_types() == [pl.DataFrame]
     assert kwargs1["compression"] == "zstd"
     assert kwargs2["n_rows"] == 2
@@ -107,7 +107,7 @@ def test_polars_feather(tmp_path: pathlib.Path) -> None:
     assert "n_rows" not in read_kwargs
     assert df.shape == (4, 3)
 
-    assert PolarsFeatherWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
+    assert PolarsFeatherWriter.applicable_types() == [pl.DataFrame]
     assert "compression" in write_kwargs
     assert file_path.exists()
     assert metadata["file_metadata"]["path"] == str(file_path)
@@ -140,7 +140,7 @@ def test_polars_ndjson(df: pl.DataFrame, tmp_path: pathlib.Path) -> None:
     kwargs2 = reader._get_loading_kwargs()
     df2, metadata = reader.load_data(pl.DataFrame)
 
-    assert PolarsNDJSONWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
+    assert PolarsNDJSONWriter.applicable_types() == [pl.DataFrame]
     assert PolarsNDJSONReader.applicable_types() == [pl.DataFrame]
     assert df2.shape == (2, 2)
     assert "schema" not in kwargs2

--- a/tests/plugins/test_polars_lazyframe_extensions.py
+++ b/tests/plugins/test_polars_lazyframe_extensions.py
@@ -23,10 +23,15 @@ import pytest
 from polars.testing import assert_frame_equal
 from sqlalchemy import create_engine
 
+
 from hamilton.plugins.polars_lazyframe_extensions import (
     PolarsScanCSVReader,
     PolarsScanFeatherReader,
     PolarsScanParquetReader,
+    PolarsLazyFrameSinkParquet,
+    PolarsLazyFrameSinkCSV,
+    PolarsLazyFrameSinkIPC,
+    PolarsLazyFrameSinkNDJSON,
 )
 from hamilton.plugins.polars_post_1_0_0_extensions import (
     PolarsAvroReader,
@@ -211,3 +216,45 @@ def test_polars_spreadsheet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     assert write_kwargs["include_header"] is True
     assert "raise_if_empty" in read_kwargs
     assert read_kwargs["raise_if_empty"] is True
+
+#####
+
+def test_polars_lazyframe_sink_parquet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
+    file = tmp_path / "test.parquet"
+    sink = PolarsLazyFrameSinkParquet(path=file)
+    metadata = sink.save_data(df)
+    df2 = pl.read_parquet(file)
+    assert PolarsLazyFrameSinkParquet.applicable_types() == [pl.LazyFrame]
+    assert file.exists()
+    assert_frame_equal(df.collect(), df2)
+
+
+def test_polars_lazyframe_sink_csv(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
+    file = tmp_path / "test.csv"
+    sink = PolarsLazyFrameSinkCSV(path=file)
+    metadata = sink.save_data(df)
+    df2 = pl.read_csv(file)
+    assert PolarsLazyFrameSinkCSV.applicable_types() == [pl.LazyFrame]
+    assert file.exists()
+    assert_frame_equal(df.collect(), df2)
+
+
+def test_polars_lazyframe_sink_ipc(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
+    file = tmp_path / "test.ipc"
+    sink = PolarsLazyFrameSinkIPC(path=file)
+    metadata = sink.save_data(df)
+    df2 = pl.read_ipc(file)
+    assert PolarsLazyFrameSinkIPC.applicable_types() == [pl.LazyFrame]
+    assert file.exists()
+    assert_frame_equal(df.collect(), df2)
+
+
+def test_polars_lazyframe_sink_ndjson(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
+    file = tmp_path / "test.ndjson"
+    sink = PolarsLazyFrameSinkNDJSON(path=file)
+    metadata = sink.save_data(df)
+    df2 = pl.read_ndjson(file)
+    assert PolarsLazyFrameSinkNDJSON.applicable_types() == [pl.LazyFrame]
+    assert file.exists()
+    assert_frame_equal(df.collect(), df2)
+

--- a/tests/plugins/test_polars_lazyframe_extensions.py
+++ b/tests/plugins/test_polars_lazyframe_extensions.py
@@ -23,15 +23,14 @@ import pytest
 from polars.testing import assert_frame_equal
 from sqlalchemy import create_engine
 
-
 from hamilton.plugins.polars_lazyframe_extensions import (
     PolarsScanCSVReader,
     PolarsScanFeatherReader,
     PolarsScanParquetReader,
-    PolarsSinkParquetWriter,
     PolarsSinkCSVWriter,
     PolarsSinkFeatherWriter,
     PolarsSinkNDJSONWriter,
+    PolarsSinkParquetWriter,
 )
 from hamilton.plugins.polars_post_1_0_0_extensions import (
     PolarsAvroReader,
@@ -64,7 +63,7 @@ def test_lazy_polars_lazyframe_csv(df: pl.LazyFrame, tmp_path: pathlib.Path) -> 
 
     reader = PolarsScanCSVReader(file=file)
     kwargs2 = reader._get_loading_kwargs()
-    df2, metadata = reader.load_data(pl.LazyFrame)
+    df2, _metadata = reader.load_data(pl.LazyFrame)
 
     assert PolarsCSVWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
     assert PolarsScanCSVReader.applicable_types() == [pl.LazyFrame]
@@ -82,7 +81,7 @@ def test_lazy_polars_parquet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
 
     reader = PolarsScanParquetReader(file=file, n_rows=2)
     kwargs2 = reader._get_loading_kwargs()
-    df2, metadata = reader.load_data(pl.LazyFrame)
+    df2, _metadata = reader.load_data(pl.LazyFrame)
 
     assert PolarsParquetWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
     assert PolarsScanParquetReader.applicable_types() == [pl.LazyFrame]
@@ -127,7 +126,7 @@ def test_lazy_polars_avro(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
 
     reader = PolarsAvroReader(file=file, n_rows=2)
     kwargs2 = reader._get_loading_kwargs()
-    df2, metadata = reader.load_data(pl.DataFrame)
+    df2, _metadata = reader.load_data(pl.DataFrame)
 
     assert PolarsAvroWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
     assert PolarsAvroReader.applicable_types() == [pl.DataFrame]
@@ -143,7 +142,7 @@ def test_polars_json(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
 
     reader = PolarsJSONReader(source=file)
     kwargs2 = reader._get_loading_kwargs()
-    df2, metadata = reader.load_data(pl.DataFrame)
+    df2, _metadata = reader.load_data(pl.DataFrame)
 
     assert PolarsJSONWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
     assert PolarsJSONReader.applicable_types() == [pl.DataFrame]
@@ -159,7 +158,7 @@ def test_polars_ndjson(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
 
     reader = PolarsNDJSONReader(source=file)
     kwargs2 = reader._get_loading_kwargs()
-    df2, metadata = reader.load_data(pl.DataFrame)
+    df2, _metadata = reader.load_data(pl.DataFrame)
 
     assert PolarsNDJSONWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
     assert PolarsNDJSONReader.applicable_types() == [pl.DataFrame]
@@ -184,7 +183,7 @@ def test_polars_database(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
 
     reader = PolarsDatabaseReader(query=f"SELECT * FROM {table_name}", connection=connector)
     kwargs2 = reader._get_loading_kwargs()
-    df2, metadata = reader.load_data(pl.DataFrame)
+    df2, _metadata = reader.load_data(pl.DataFrame)
 
     assert PolarsDatabaseWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
     assert PolarsDatabaseReader.applicable_types() == [pl.DataFrame]
@@ -217,7 +216,6 @@ def test_polars_spreadsheet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     assert "raise_if_empty" in read_kwargs
     assert read_kwargs["raise_if_empty"] is True
 
-#####
 
 def test_polars_lazyframe_sink_parquet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test.parquet"
@@ -225,9 +223,26 @@ def test_polars_lazyframe_sink_parquet(df: pl.LazyFrame, tmp_path: pathlib.Path)
     kwargs = sink._get_saving_kwargs()
     sink.save_data(df)
     df2 = pl.read_parquet(file)
+
     assert PolarsSinkParquetWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
     assert kwargs["compression"] == "zstd"
+    assert_frame_equal(df.collect(), df2)
+
+
+def test_polars_lazyframe_sink_parquet_custom_kwargs(
+    df: pl.LazyFrame, tmp_path: pathlib.Path
+) -> None:
+    """Test that non-default kwargs are passed through correctly."""
+    file = tmp_path / "test.parquet"
+    sink = PolarsSinkParquetWriter(path=file, compression="snappy", maintain_order=False)
+    kwargs = sink._get_saving_kwargs()
+    sink.save_data(df)
+    df2 = pl.read_parquet(file)
+
+    assert kwargs["compression"] == "snappy"
+    assert kwargs["maintain_order"] is False
+    assert file.exists()
     assert_frame_equal(df.collect(), df2)
 
 
@@ -237,9 +252,25 @@ def test_polars_lazyframe_sink_csv(df: pl.LazyFrame, tmp_path: pathlib.Path) -> 
     kwargs = sink._get_saving_kwargs()
     sink.save_data(df)
     df2 = pl.read_csv(file)
+
     assert PolarsSinkCSVWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
     assert kwargs["separator"] == ","
+    assert kwargs["include_header"] is True
+    assert_frame_equal(df.collect(), df2)
+
+
+def test_polars_lazyframe_sink_csv_custom_kwargs(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
+    """Test that non-default kwargs are passed through correctly."""
+    file = tmp_path / "test.csv"
+    sink = PolarsSinkCSVWriter(path=file, separator=";", include_header=False)
+    kwargs = sink._get_saving_kwargs()
+    sink.save_data(df)
+    df2 = pl.read_csv(file, separator=";", has_header=False, new_columns=["a", "b"])
+
+    assert kwargs["separator"] == ";"
+    assert kwargs["include_header"] is False
+    assert file.exists()
     assert_frame_equal(df.collect(), df2)
 
 
@@ -249,9 +280,24 @@ def test_polars_lazyframe_sink_ipc(df: pl.LazyFrame, tmp_path: pathlib.Path) -> 
     kwargs = sink._get_saving_kwargs()
     sink.save_data(df)
     df2 = pl.read_ipc(file)
+
     assert PolarsSinkFeatherWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
     assert kwargs["compression"] == "uncompressed"
+    assert_frame_equal(df.collect(), df2)
+
+
+def test_polars_lazyframe_sink_ipc_custom_kwargs(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
+    """Test that non-default kwargs are passed through correctly."""
+    file = tmp_path / "test.ipc"
+    sink = PolarsSinkFeatherWriter(path=file, compression="lz4", maintain_order=False)
+    kwargs = sink._get_saving_kwargs()
+    sink.save_data(df)
+    df2 = pl.read_ipc(file)
+
+    assert kwargs["compression"] == "lz4"
+    assert kwargs["maintain_order"] is False
+    assert file.exists()
     assert_frame_equal(df.collect(), df2)
 
 
@@ -261,48 +307,43 @@ def test_polars_lazyframe_sink_ndjson(df: pl.LazyFrame, tmp_path: pathlib.Path) 
     kwargs = sink._get_saving_kwargs()
     sink.save_data(df)
     df2 = pl.read_ndjson(file)
+
     assert PolarsSinkNDJSONWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
     assert kwargs["maintain_order"] is True
     assert_frame_equal(df.collect(), df2)
 
 
-# def test_polars_lazyframe_sink_parquet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
-#     file = tmp_path / "test.parquet"
-#     sink = PolarsLazyFrameSinkParquet(path=file)
-#     metadata = sink.save_data(df)
-#     df2 = pl.read_parquet(file)
-#     assert PolarsLazyFrameSinkParquet.applicable_types() == [pl.LazyFrame]
-#     assert file.exists()
-#     assert_frame_equal(df.collect(), df2)
+def test_polars_lazyframe_sink_ndjson_custom_kwargs(
+    df: pl.LazyFrame, tmp_path: pathlib.Path
+) -> None:
+    """Test that non-default kwargs are passed through correctly."""
+    file = tmp_path / "test.ndjson"
+    sink = PolarsSinkNDJSONWriter(path=file, maintain_order=False)
+    kwargs = sink._get_saving_kwargs()
+    sink.save_data(df)
+    df2 = pl.read_ndjson(file)
+
+    assert kwargs["maintain_order"] is False
+    assert file.exists()
+    assert_frame_equal(df.collect(), df2)
 
 
-# def test_polars_lazyframe_sink_csv(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
-#     file = tmp_path / "test.csv"
-#     sink = PolarsLazyFrameSinkCSV(path=file)
-#     metadata = sink.save_data(df)
-#     df2 = pl.read_csv(file)
-#     assert PolarsLazyFrameSinkCSV.applicable_types() == [pl.LazyFrame]
-#     assert file.exists()
-#     assert_frame_equal(df.collect(), df2)
+def test_polars_lazyframe_sink_feather_adapter_name() -> None:
+    """Test that PolarsSinkFeatherWriter is registered under 'feather', not 'ipc'."""
+    assert PolarsSinkFeatherWriter.name() == "feather"
 
 
-# def test_polars_lazyframe_sink_ipc(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
-#     file = tmp_path / "test.ipc"
-#     sink = PolarsLazyFrameSinkIPC(path=file)
-#     metadata = sink.save_data(df)
-#     df2 = pl.read_ipc(file)
-#     assert PolarsLazyFrameSinkIPC.applicable_types() == [pl.LazyFrame]
-#     assert file.exists()
-#     assert_frame_equal(df.collect(), df2)
+def test_polars_lazyframe_sink_csv_adapter_name() -> None:
+    """Test that PolarsSinkCSVWriter is registered under 'csv'."""
+    assert PolarsSinkCSVWriter.name() == "csv"
 
 
-# def test_polars_lazyframe_sink_ndjson(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
-#     file = tmp_path / "test.ndjson"
-#     sink = PolarsLazyFrameSinkNDJSON(path=file)
-#     metadata = sink.save_data(df)
-#     df2 = pl.read_ndjson(file)
-#     assert PolarsLazyFrameSinkNDJSON.applicable_types() == [pl.LazyFrame]
-#     assert file.exists()
-#     assert_frame_equal(df.collect(), df2)
+def test_polars_lazyframe_sink_parquet_adapter_name() -> None:
+    """Test that PolarsSinkParquetWriter is registered under 'parquet'."""
+    assert PolarsSinkParquetWriter.name() == "parquet"
 
+
+def test_polars_lazyframe_sink_ndjson_adapter_name() -> None:
+    """Test that PolarsSinkNDJSONWriter is registered under 'ndjson'."""
+    assert PolarsSinkNDJSONWriter.name() == "ndjson"

--- a/tests/plugins/test_polars_lazyframe_extensions.py
+++ b/tests/plugins/test_polars_lazyframe_extensions.py
@@ -38,12 +38,15 @@ from hamilton.plugins.polars_lazyframe_extensions import (
 from hamilton.plugins.polars_post_1_0_0_extensions import (
     PolarsAvroReader,
     PolarsAvroWriter,
+    PolarsCSVWriter,
     PolarsDatabaseReader,
     PolarsDatabaseWriter,
     PolarsFeatherWriter,
     PolarsJSONReader,
     PolarsJSONWriter,
     PolarsNDJSONReader,
+    PolarsNDJSONWriter,
+    PolarsParquetWriter,
     PolarsSpreadsheetReader,
     PolarsSpreadsheetWriter,
 )
@@ -294,7 +297,7 @@ def test_polars_lazyframe_sink_ipc(df: pl.LazyFrame, tmp_path: pathlib.Path) -> 
 
     assert PolarsSinkFeatherWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
-    assert kwargs["compression"] == "uncompressed"
+    assert "compression" not in kwargs
     assert metadata["file_metadata"]["path"] == str(file)
     assert_frame_equal(df.collect(), df2)
 
@@ -408,6 +411,42 @@ def test_lazyframe_sink_csv_complete_kwargs(tmp_path: pathlib.Path) -> None:
     assert sink._get_saving_kwargs()["decimal_comma"] is True
     assert sink._get_saving_kwargs()["storage_options"] == {"key": "value"}
     assert sink._get_saving_kwargs()["retries"] == 7
+
+
+@pytest.mark.parametrize(
+    "sink_class",
+    [
+        PolarsSinkCSVWriter,
+        PolarsSinkParquetWriter,
+        PolarsSinkFeatherWriter,
+        PolarsSinkNDJSONWriter,
+    ],
+)
+def test_lazyframe_sinks_reject_lazy_extra_kwarg(sink_class, tmp_path: pathlib.Path) -> None:
+    sink = sink_class(file=tmp_path / "output", extra_kwargs={"lazy": True})
+
+    with pytest.raises(ValueError, match="lazy=True"):
+        sink._get_saving_kwargs()
+
+
+@pytest.mark.parametrize(
+    ("writer_class", "extension"),
+    [
+        (PolarsCSVWriter, "csv"),
+        (PolarsParquetWriter, "parquet"),
+        (PolarsFeatherWriter, "ipc"),
+        (PolarsNDJSONWriter, "ndjson"),
+    ],
+)
+def test_eager_writers_preserve_direct_lazyframe_support(
+    writer_class, extension: str, df: pl.LazyFrame, tmp_path: pathlib.Path
+) -> None:
+    output_file = tmp_path / f"output.{extension}"
+
+    metadata = writer_class(file=output_file).save_data(df)
+
+    assert output_file.exists()
+    assert metadata["dataframe_metadata"]["rows"] == 2
 
 
 def test_lazyframe_sink_materializer_preserves_file_argument(tmp_path: pathlib.Path) -> None:

--- a/tests/plugins/test_polars_lazyframe_extensions.py
+++ b/tests/plugins/test_polars_lazyframe_extensions.py
@@ -23,6 +23,9 @@ import pytest
 from polars.testing import assert_frame_equal
 from sqlalchemy import create_engine
 
+from hamilton import ad_hoc_utils, driver, registry
+from hamilton.function_modifiers.adapters import resolve_adapter_class
+from hamilton.io.materialization import to
 from hamilton.plugins.polars_lazyframe_extensions import (
     PolarsScanCSVReader,
     PolarsScanFeatherReader,
@@ -35,17 +38,23 @@ from hamilton.plugins.polars_lazyframe_extensions import (
 from hamilton.plugins.polars_post_1_0_0_extensions import (
     PolarsAvroReader,
     PolarsAvroWriter,
-    PolarsCSVWriter,
     PolarsDatabaseReader,
     PolarsDatabaseWriter,
     PolarsFeatherWriter,
     PolarsJSONReader,
     PolarsJSONWriter,
     PolarsNDJSONReader,
-    PolarsNDJSONWriter,
-    PolarsParquetWriter,
     PolarsSpreadsheetReader,
     PolarsSpreadsheetWriter,
+)
+from hamilton.plugins.polars_pre_1_0_0_extension import (
+    PolarsCSVWriter as Pre1PolarsCSVWriter,
+)
+from hamilton.plugins.polars_pre_1_0_0_extension import (
+    PolarsFeatherWriter as Pre1PolarsFeatherWriter,
+)
+from hamilton.plugins.polars_pre_1_0_0_extension import (
+    PolarsParquetWriter as Pre1PolarsParquetWriter,
 )
 
 
@@ -57,7 +66,7 @@ def df():
 def test_lazy_polars_lazyframe_csv(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test.csv"
 
-    writer = PolarsCSVWriter(file=file)
+    writer = PolarsSinkCSVWriter(file=file)
     kwargs1 = writer._get_saving_kwargs()
     writer.save_data(df)
 
@@ -65,7 +74,7 @@ def test_lazy_polars_lazyframe_csv(df: pl.LazyFrame, tmp_path: pathlib.Path) -> 
     kwargs2 = reader._get_loading_kwargs()
     df2, _metadata = reader.load_data(pl.LazyFrame)
 
-    assert PolarsCSVWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
+    assert PolarsSinkCSVWriter.applicable_types() == [pl.LazyFrame]
     assert PolarsScanCSVReader.applicable_types() == [pl.LazyFrame]
     assert kwargs1["separator"] == ","
     assert kwargs2["has_header"] is True
@@ -75,7 +84,7 @@ def test_lazy_polars_lazyframe_csv(df: pl.LazyFrame, tmp_path: pathlib.Path) -> 
 def test_lazy_polars_parquet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test.parquet"
 
-    writer = PolarsParquetWriter(file=file)
+    writer = PolarsSinkParquetWriter(file=file)
     kwargs1 = writer._get_saving_kwargs()
     writer.save_data(df)
 
@@ -83,7 +92,7 @@ def test_lazy_polars_parquet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     kwargs2 = reader._get_loading_kwargs()
     df2, _metadata = reader.load_data(pl.LazyFrame)
 
-    assert PolarsParquetWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
+    assert PolarsSinkParquetWriter.applicable_types() == [pl.LazyFrame]
     assert PolarsScanParquetReader.applicable_types() == [pl.LazyFrame]
     assert kwargs1["compression"] == "zstd"
     assert kwargs2["n_rows"] == 2
@@ -105,7 +114,7 @@ def test_lazy_polars_feather(tmp_path: pathlib.Path) -> None:
     assert "n_rows" not in read_kwargs
     assert df.collect().shape == (4, 3)
 
-    assert PolarsFeatherWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
+    assert PolarsFeatherWriter.applicable_types() == [pl.DataFrame]
     assert "compression" in write_kwargs
     assert file_path.exists()
     assert metadata["file_metadata"]["path"] == str(file_path)
@@ -153,14 +162,14 @@ def test_polars_json(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
 
 def test_polars_ndjson(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test.ndjson"
-    writer = PolarsNDJSONWriter(file=file)
+    writer = PolarsSinkNDJSONWriter(file=file)
     writer.save_data(df)
 
     reader = PolarsNDJSONReader(source=file)
     kwargs2 = reader._get_loading_kwargs()
     df2, _metadata = reader.load_data(pl.DataFrame)
 
-    assert PolarsNDJSONWriter.applicable_types() == [pl.DataFrame, pl.LazyFrame]
+    assert PolarsSinkNDJSONWriter.applicable_types() == [pl.LazyFrame]
     assert PolarsNDJSONReader.applicable_types() == [pl.DataFrame]
     assert df2.shape == (2, 2)
     assert "schema" not in kwargs2
@@ -219,14 +228,15 @@ def test_polars_spreadsheet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
 
 def test_polars_lazyframe_sink_parquet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test.parquet"
-    sink = PolarsSinkParquetWriter(path=file)
+    sink = PolarsSinkParquetWriter(file=file)
     kwargs = sink._get_saving_kwargs()
-    sink.save_data(df)
+    metadata = sink.save_data(df)
     df2 = pl.read_parquet(file)
 
     assert PolarsSinkParquetWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
     assert kwargs["compression"] == "zstd"
+    assert metadata["file_metadata"]["path"] == str(file)
     assert_frame_equal(df.collect(), df2)
 
 
@@ -235,7 +245,7 @@ def test_polars_lazyframe_sink_parquet_custom_kwargs(
 ) -> None:
     """Test that non-default kwargs are passed through correctly."""
     file = tmp_path / "test.parquet"
-    sink = PolarsSinkParquetWriter(path=file, compression="snappy", maintain_order=False)
+    sink = PolarsSinkParquetWriter(file=file, compression="snappy", maintain_order=False)
     kwargs = sink._get_saving_kwargs()
     sink.save_data(df)
     df2 = pl.read_parquet(file)
@@ -243,27 +253,28 @@ def test_polars_lazyframe_sink_parquet_custom_kwargs(
     assert kwargs["compression"] == "snappy"
     assert kwargs["maintain_order"] is False
     assert file.exists()
-    assert_frame_equal(df.collect(), df2)
+    assert_frame_equal(df.collect().sort(["a", "b"]), df2.sort(["a", "b"]))
 
 
 def test_polars_lazyframe_sink_csv(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test.csv"
-    sink = PolarsSinkCSVWriter(path=file)
+    sink = PolarsSinkCSVWriter(file=file)
     kwargs = sink._get_saving_kwargs()
-    sink.save_data(df)
+    metadata = sink.save_data(df)
     df2 = pl.read_csv(file)
 
     assert PolarsSinkCSVWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
     assert kwargs["separator"] == ","
     assert kwargs["include_header"] is True
+    assert metadata["file_metadata"]["path"] == str(file)
     assert_frame_equal(df.collect(), df2)
 
 
 def test_polars_lazyframe_sink_csv_custom_kwargs(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     """Test that non-default kwargs are passed through correctly."""
     file = tmp_path / "test.csv"
-    sink = PolarsSinkCSVWriter(path=file, separator=";", include_header=False)
+    sink = PolarsSinkCSVWriter(file=file, separator=";", include_header=False)
     kwargs = sink._get_saving_kwargs()
     sink.save_data(df)
     df2 = pl.read_csv(file, separator=";", has_header=False, new_columns=["a", "b"])
@@ -276,21 +287,22 @@ def test_polars_lazyframe_sink_csv_custom_kwargs(df: pl.LazyFrame, tmp_path: pat
 
 def test_polars_lazyframe_sink_ipc(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test.ipc"
-    sink = PolarsSinkFeatherWriter(path=file)
+    sink = PolarsSinkFeatherWriter(file=file)
     kwargs = sink._get_saving_kwargs()
-    sink.save_data(df)
+    metadata = sink.save_data(df)
     df2 = pl.read_ipc(file)
 
     assert PolarsSinkFeatherWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
     assert kwargs["compression"] == "uncompressed"
+    assert metadata["file_metadata"]["path"] == str(file)
     assert_frame_equal(df.collect(), df2)
 
 
 def test_polars_lazyframe_sink_ipc_custom_kwargs(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     """Test that non-default kwargs are passed through correctly."""
     file = tmp_path / "test.ipc"
-    sink = PolarsSinkFeatherWriter(path=file, compression="lz4", maintain_order=False)
+    sink = PolarsSinkFeatherWriter(file=file, compression="lz4", maintain_order=False)
     kwargs = sink._get_saving_kwargs()
     sink.save_data(df)
     df2 = pl.read_ipc(file)
@@ -298,19 +310,20 @@ def test_polars_lazyframe_sink_ipc_custom_kwargs(df: pl.LazyFrame, tmp_path: pat
     assert kwargs["compression"] == "lz4"
     assert kwargs["maintain_order"] is False
     assert file.exists()
-    assert_frame_equal(df.collect(), df2)
+    assert_frame_equal(df.collect().sort(["a", "b"]), df2.sort(["a", "b"]))
 
 
 def test_polars_lazyframe_sink_ndjson(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test.ndjson"
-    sink = PolarsSinkNDJSONWriter(path=file)
+    sink = PolarsSinkNDJSONWriter(file=file)
     kwargs = sink._get_saving_kwargs()
-    sink.save_data(df)
+    metadata = sink.save_data(df)
     df2 = pl.read_ndjson(file)
 
     assert PolarsSinkNDJSONWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
     assert kwargs["maintain_order"] is True
+    assert metadata["file_metadata"]["path"] == str(file)
     assert_frame_equal(df.collect(), df2)
 
 
@@ -319,14 +332,14 @@ def test_polars_lazyframe_sink_ndjson_custom_kwargs(
 ) -> None:
     """Test that non-default kwargs are passed through correctly."""
     file = tmp_path / "test.ndjson"
-    sink = PolarsSinkNDJSONWriter(path=file, maintain_order=False)
+    sink = PolarsSinkNDJSONWriter(file=file, maintain_order=False)
     kwargs = sink._get_saving_kwargs()
     sink.save_data(df)
     df2 = pl.read_ndjson(file)
 
     assert kwargs["maintain_order"] is False
     assert file.exists()
-    assert_frame_equal(df.collect(), df2)
+    assert_frame_equal(df.collect().sort(["a", "b"]), df2.sort(["a", "b"]))
 
 
 def test_polars_lazyframe_sink_feather_adapter_name() -> None:
@@ -347,3 +360,69 @@ def test_polars_lazyframe_sink_parquet_adapter_name() -> None:
 def test_polars_lazyframe_sink_ndjson_adapter_name() -> None:
     """Test that PolarsSinkNDJSONWriter is registered under 'ndjson'."""
     assert PolarsSinkNDJSONWriter.name() == "ndjson"
+
+
+@pytest.mark.parametrize(
+    ("adapter_name", "expected_saver"),
+    [
+        ("csv", PolarsSinkCSVWriter),
+        ("parquet", PolarsSinkParquetWriter),
+        ("feather", PolarsSinkFeatherWriter),
+        ("ndjson", PolarsSinkNDJSONWriter),
+    ],
+)
+def test_lazyframe_sink_registry_resolution(adapter_name, expected_saver) -> None:
+    """Each format resolves one LazyFrame saver, independent of registration order."""
+    registered_savers = registry.SAVER_REGISTRY[adapter_name]
+    applicable_savers = [saver for saver in registered_savers if saver.applies_to(pl.LazyFrame)]
+
+    assert applicable_savers == [expected_saver]
+    assert resolve_adapter_class(pl.LazyFrame, registered_savers) is expected_saver
+    assert resolve_adapter_class(pl.LazyFrame, list(reversed(registered_savers))) is expected_saver
+
+
+@pytest.mark.parametrize(
+    ("eager_saver", "streaming_saver"),
+    [
+        (Pre1PolarsCSVWriter, PolarsSinkCSVWriter),
+        (Pre1PolarsParquetWriter, PolarsSinkParquetWriter),
+        (Pre1PolarsFeatherWriter, PolarsSinkFeatherWriter),
+    ],
+)
+def test_pre_1_0_lazyframe_sink_resolution_is_unambiguous(eager_saver, streaming_saver) -> None:
+    assert eager_saver.applicable_types() == [pl.DataFrame]
+    assert resolve_adapter_class(pl.LazyFrame, [eager_saver, streaming_saver]) is streaming_saver
+    assert resolve_adapter_class(pl.LazyFrame, [streaming_saver, eager_saver]) is streaming_saver
+
+
+def test_lazyframe_sink_csv_complete_kwargs(tmp_path: pathlib.Path) -> None:
+    sink = PolarsSinkCSVWriter(
+        file=tmp_path / "output.csv",
+        include_bom=True,
+        decimal_comma=True,
+        storage_options={"key": "value"},
+        extra_kwargs={"retries": 7},
+    )
+
+    assert sink._get_saving_kwargs()["include_bom"] is True
+    assert sink._get_saving_kwargs()["decimal_comma"] is True
+    assert sink._get_saving_kwargs()["storage_options"] == {"key": "value"}
+    assert sink._get_saving_kwargs()["retries"] == 7
+
+
+def test_lazyframe_sink_materializer_preserves_file_argument(tmp_path: pathlib.Path) -> None:
+    """The streaming saver must remain compatible with the existing Polars ``file`` API."""
+
+    def lazy_data() -> pl.LazyFrame:
+        return pl.LazyFrame({"a": [1, 2], "b": [3, 4]})
+
+    output_file = tmp_path / "output.csv"
+    module = ad_hoc_utils.create_temporary_module(lazy_data)
+    dr = driver.Driver({}, module)
+
+    materialization_result, _ = dr.materialize(
+        to.csv(id="save_lazy_data", dependencies=["lazy_data"], file=output_file)
+    )
+
+    assert materialization_result["save_lazy_data"]["file_metadata"]["path"] == str(output_file)
+    assert_frame_equal(pl.read_csv(output_file), lazy_data().collect())

--- a/tests/plugins/test_polars_lazyframe_extensions.py
+++ b/tests/plugins/test_polars_lazyframe_extensions.py
@@ -28,10 +28,10 @@ from hamilton.plugins.polars_lazyframe_extensions import (
     PolarsScanCSVReader,
     PolarsScanFeatherReader,
     PolarsScanParquetReader,
-    PolarsLazyFrameSinkParquet,
-    PolarsLazyFrameSinkCSV,
-    PolarsLazyFrameSinkIPC,
-    PolarsLazyFrameSinkNDJSON,
+    PolarsSinkParquetWriter,
+    PolarsSinkCSVWriter,
+    PolarsSinkFeatherWriter,
+    PolarsSinkNDJSONWriter,
 )
 from hamilton.plugins.polars_post_1_0_0_extensions import (
     PolarsAvroReader,
@@ -221,40 +221,88 @@ def test_polars_spreadsheet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
 
 def test_polars_lazyframe_sink_parquet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test.parquet"
-    sink = PolarsLazyFrameSinkParquet(path=file)
-    metadata = sink.save_data(df)
+    sink = PolarsSinkParquetWriter(path=file)
+    kwargs = sink._get_saving_kwargs()
+    sink.save_data(df)
     df2 = pl.read_parquet(file)
-    assert PolarsLazyFrameSinkParquet.applicable_types() == [pl.LazyFrame]
+    assert PolarsSinkParquetWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
+    assert kwargs["compression"] == "zstd"
     assert_frame_equal(df.collect(), df2)
 
 
 def test_polars_lazyframe_sink_csv(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test.csv"
-    sink = PolarsLazyFrameSinkCSV(path=file)
-    metadata = sink.save_data(df)
+    sink = PolarsSinkCSVWriter(path=file)
+    kwargs = sink._get_saving_kwargs()
+    sink.save_data(df)
     df2 = pl.read_csv(file)
-    assert PolarsLazyFrameSinkCSV.applicable_types() == [pl.LazyFrame]
+    assert PolarsSinkCSVWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
+    assert kwargs["separator"] == ","
     assert_frame_equal(df.collect(), df2)
 
 
 def test_polars_lazyframe_sink_ipc(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test.ipc"
-    sink = PolarsLazyFrameSinkIPC(path=file)
-    metadata = sink.save_data(df)
+    sink = PolarsSinkFeatherWriter(path=file)
+    kwargs = sink._get_saving_kwargs()
+    sink.save_data(df)
     df2 = pl.read_ipc(file)
-    assert PolarsLazyFrameSinkIPC.applicable_types() == [pl.LazyFrame]
+    assert PolarsSinkFeatherWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
+    assert kwargs["compression"] == "uncompressed"
     assert_frame_equal(df.collect(), df2)
 
 
 def test_polars_lazyframe_sink_ndjson(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
     file = tmp_path / "test.ndjson"
-    sink = PolarsLazyFrameSinkNDJSON(path=file)
-    metadata = sink.save_data(df)
+    sink = PolarsSinkNDJSONWriter(path=file)
+    kwargs = sink._get_saving_kwargs()
+    sink.save_data(df)
     df2 = pl.read_ndjson(file)
-    assert PolarsLazyFrameSinkNDJSON.applicable_types() == [pl.LazyFrame]
+    assert PolarsSinkNDJSONWriter.applicable_types() == [pl.LazyFrame]
     assert file.exists()
+    assert kwargs["maintain_order"] is True
     assert_frame_equal(df.collect(), df2)
+
+
+# def test_polars_lazyframe_sink_parquet(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
+#     file = tmp_path / "test.parquet"
+#     sink = PolarsLazyFrameSinkParquet(path=file)
+#     metadata = sink.save_data(df)
+#     df2 = pl.read_parquet(file)
+#     assert PolarsLazyFrameSinkParquet.applicable_types() == [pl.LazyFrame]
+#     assert file.exists()
+#     assert_frame_equal(df.collect(), df2)
+
+
+# def test_polars_lazyframe_sink_csv(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
+#     file = tmp_path / "test.csv"
+#     sink = PolarsLazyFrameSinkCSV(path=file)
+#     metadata = sink.save_data(df)
+#     df2 = pl.read_csv(file)
+#     assert PolarsLazyFrameSinkCSV.applicable_types() == [pl.LazyFrame]
+#     assert file.exists()
+#     assert_frame_equal(df.collect(), df2)
+
+
+# def test_polars_lazyframe_sink_ipc(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
+#     file = tmp_path / "test.ipc"
+#     sink = PolarsLazyFrameSinkIPC(path=file)
+#     metadata = sink.save_data(df)
+#     df2 = pl.read_ipc(file)
+#     assert PolarsLazyFrameSinkIPC.applicable_types() == [pl.LazyFrame]
+#     assert file.exists()
+#     assert_frame_equal(df.collect(), df2)
+
+
+# def test_polars_lazyframe_sink_ndjson(df: pl.LazyFrame, tmp_path: pathlib.Path) -> None:
+#     file = tmp_path / "test.ndjson"
+#     sink = PolarsLazyFrameSinkNDJSON(path=file)
+#     metadata = sink.save_data(df)
+#     df2 = pl.read_ndjson(file)
+#     assert PolarsLazyFrameSinkNDJSON.applicable_types() == [pl.LazyFrame]
+#     assert file.exists()
+#     assert_frame_equal(df.collect(), df2)
 


### PR DESCRIPTION
## Summary
Closes #791

Adds data sink support for Polars LazyFrames, allowing users to write
LazyFrames directly to disk without calling lf.collect() first, which
is more performant.

## Changes
- Added `PolarsLazyFrameSinkParquet` class
- Added `PolarsLazyFrameSinkCSV` class
- Added `PolarsLazyFrameSinkIPC` class
- Added `PolarsLazyFrameSinkNDJSON` class
- Registered all new sinks in `register_data_loaders()`

## How I tested this
Added 4 new tests in `tests/plugins/test_polars_lazyframe_extensions.py`:
- `test_polars_lazyframe_sink_parquet` ✅
- `test_polars_lazyframe_sink_csv` ✅
- `test_polars_lazyframe_sink_ipc` ✅
- `test_polars_lazyframe_sink_ndjson` ✅

Each test creates a LazyFrame, sinks it to a temp file, reads it back,
and verifies the data matches.

## Notes
- `sink_ndjson` has no corresponding loader yet as noted in the issue

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Any change in functionality is tested
- [x] New functions are documented (with a description and docstring)
