### PR TITLE
fix(with_columns): require exactly one of pass_dataframe_as / columns_to_pass / on_input

### DIFF
--- a/hamilton/function_modifiers/recursive.py
+++ b/hamilton/function_modifiers/recursive.py
@@ -803,12 +803,11 @@ class with_columns_base(base.NodeInjector, abc.ABC):
         # We can decouple it so that on_input selects the target dataframe parameter that will inject into the next node
         # pass_dataframe_as selects the original dataframe we want to extract columns from
         # columns_to_pass is optinal helper that can be toggled on/off so no need to raise this error.
-        if (
-            int(pass_dataframe_as is None) + int(columns_to_pass is None) + int(on_input is None)
-            == 1
-        ):
+        n_set = sum(arg is not None for arg in (pass_dataframe_as, columns_to_pass, on_input))
+        if n_set != 1:
             raise ValueError(
-                "You must specify only one of ``columns_to_pass``, ``pass_dataframe_as``, and ``on_input``. "
+                "You must specify exactly one of ``columns_to_pass``, ``pass_dataframe_as``, "
+                "and ``on_input``. "
                 "This is because specifying ``pass_dataframe_as`` or ``on_input`` injects into "
                 "the set of columns, allowing you to perform your own extraction"
                 "from the dataframe. We then execute all columns in the subdag"

--- a/tests/function_modifiers/test_recursive.py
+++ b/tests/function_modifiers/test_recursive.py
@@ -687,3 +687,54 @@ def test_columns_and_subdag_nodes_do_not_clash():
 
     assert not with_columns_base.contains_duplicates([node_a, node_c])
     assert with_columns_base.contains_duplicates([node_a, node_b, node_c])
+
+
+class _BaseValidationSub(with_columns_base):
+    """Minimal concrete subclass used to exercise `with_columns_base.__init__`-time
+    validation. The abstract methods are trivially stubbed because no test in this
+    block invokes them.
+    """
+
+    def get_initial_nodes(self, fn, params):
+        return "", []
+
+    def get_subdag_nodes(self, fn, config):
+        return []
+
+    def chain_subdag_nodes(self, fn, inject_parameter, generated_nodes):
+        return None
+
+    def validate(self, fn):
+        pass
+
+
+def _dummy_subdag_fn() -> int:
+    return 0
+
+
+def test_with_columns_base_raises_when_no_mutex_arg_set():
+    with pytest.raises(ValueError, match="exactly one of"):
+        _BaseValidationSub(_dummy_subdag_fn, select=["x"])
+
+
+def test_with_columns_base_raises_when_two_mutex_args_set():
+    with pytest.raises(ValueError, match="exactly one of"):
+        _BaseValidationSub(_dummy_subdag_fn, columns_to_pass=["a"], on_input="b", select=["x"])
+
+
+def test_with_columns_base_raises_when_all_three_mutex_args_set():
+    with pytest.raises(ValueError, match="exactly one of"):
+        _BaseValidationSub(
+            _dummy_subdag_fn,
+            columns_to_pass=["a"],
+            pass_dataframe_as="b",
+            on_input="c",
+            select=["x"],
+        )
+
+
+def test_with_columns_base_accepts_exactly_one_mutex_arg():
+    # Each of the three single-set cases must instantiate cleanly.
+    _BaseValidationSub(_dummy_subdag_fn, columns_to_pass=["a"], select=["x"], dataframe_type=object)
+    _BaseValidationSub(_dummy_subdag_fn, pass_dataframe_as="b", select=["x"], dataframe_type=object)
+    _BaseValidationSub(_dummy_subdag_fn, on_input="c", select=["x"], dataframe_type=object)


### PR DESCRIPTION
## Summary

`with_columns_base.__init__` is meant to enforce mutual exclusivity between `pass_dataframe_as`, `columns_to_pass`, and `on_input` — the docstring on each of those parameters says so. The current check raises only when exactly **two** are set:

```python
if (
    int(pass_dataframe_as is None) + int(columns_to_pass is None) + int(on_input is None)
    == 1
):
    raise ValueError("You must specify only one of ...")
```

So a caller who specifies all three silently passes the validation and crashes later with a confusing downstream error. A caller who specifies zero of them also silently passes.

| Args set | sum(`is None`) | currently raises? | should raise? |
|---|---|---|---|
| 0 | 3 | no | yes |
| 1 | 2 | no | no |
| 2 | 1 | yes | yes |
| 3 | 0 | no | yes |

This PR replaces the boolean arithmetic with the intuitive form:

```python
n_set = sum(arg is not None for arg in (pass_dataframe_as, columns_to_pass, on_input))
if n_set != 1:
    raise ValueError("You must specify exactly one of ...")
```

The error message opener is also tightened: `"only one of"` → `"exactly one of"`.

## Tests

Four new tests in `tests/function_modifiers/test_recursive.py`, exercising the base class directly via a minimal inline subclass:

- 0 args set → `ValueError`
- 2 args set → `ValueError` (regression of the case that was already caught)
- 3 args set → `ValueError` (new — was the primary bug)
- 1 arg set → no error (positive case across all three options)

Validation lives in the shared base class so no parallel `h_polars` / `h_spark` tests are necessary. Testing against `with_columns_base` directly (rather than e.g. `h_pandas.with_columns`) is necessary because some subclasses pre-reject certain arg combinations before delegating to the base.

## Behaviour change

Callers passing 0 or 3 of the mutually-exclusive args used to silently pass the decoration step and crash later with confusing errors deep in the DAG-build path. After this PR they get a clean `ValueError` at decoration time. This is the only intentional behavioural change. The documented contract has always been mutual exclusivity, so no caller should be relying on the silent-pass behaviour — but flagging the change explicitly so reviewers aren't surprised.

Signed-off-by: Olajumoke Akinremi <106763970+Hore01@users.noreply.github.com>
