### PR TITLE
docs(data-quality): add check_output_custom section (#212)

### DIFF
--- a/docs/how-tos/run-data-quality-checks.rst
+++ b/docs/how-tos/run-data-quality-checks.rst
@@ -34,7 +34,7 @@ A validator subclasses ``hamilton.data_quality.base.DataValidator`` and implemen
 
         @classmethod
         def applies_to(cls, datatype: type) -> bool:
-            return datatype == pd.Series
+            return issubclass(datatype, pd.Series)
 
         def description(self) -> str:
             return "Validates that the series contains no negative values."

--- a/docs/how-tos/run-data-quality-checks.rst
+++ b/docs/how-tos/run-data-quality-checks.rst
@@ -11,6 +11,102 @@ The goal of this is to show how to use runtime data quality checks in a larger, 
 1. `Data quality with hamilton <https://github.com/apache/hamilton/tree/main/examples/data_quality/simple>`_
 2. `Data quality with pandera <https://github.com/apache/hamilton/tree/main/examples/data_quality/pandera>`_
 
+Custom validators
+~~~~~~~~~~~~~~~~~
+
+The ``@check_output`` decorator ships with default validators that cover common checks (data type, range, allowed values, etc. -- see the :doc:`check_output reference <../reference/decorators/check_output>`). When you need a check they don't cover -- say, a business rule specific to your data -- you can write your own validator class and apply it with ``@check_output_custom``.
+
+A validator subclasses ``hamilton.data_quality.base.DataValidator`` and implements four methods, plus a constructor that forwards ``importance`` to the base class:
+
+.. code-block:: python
+
+    # my_module.py
+    import pandas as pd
+
+    from hamilton.data_quality import base
+
+
+    class AllPositiveValidator(base.DataValidator):
+        """Validates that a pandas series contains no negative values."""
+
+        def __init__(self, importance: str):
+            super().__init__(importance=importance)
+
+        @classmethod
+        def applies_to(cls, datatype: type) -> bool:
+            return datatype == pd.Series
+
+        def description(self) -> str:
+            return "Validates that the series contains no negative values."
+
+        @classmethod
+        def name(cls) -> str:
+            return "all_positive_validator"
+
+        def validate(self, dataset: pd.Series) -> base.ValidationResult:
+            negative_count = int((dataset < 0).sum())
+            passes = negative_count == 0
+            if passes:
+                message = "All values are non-negative."
+            else:
+                message = f"Found {negative_count} negative value(s)."
+            return base.ValidationResult(
+                passes=passes,
+                message=message,
+                diagnostics={"negative_count": negative_count, "series_length": len(dataset)},
+            )
+
+The pieces are:
+
+* ``applies_to`` -- whether this validator can run on the output type of the decorated function.
+* ``description`` -- a human-readable description of the check; it becomes the documentation of the validator's node in the DAG.
+* ``name`` -- used to name the validator's node in the DAG (see below).
+* ``validate`` -- the actual check. It receives the decorated function's output and returns a ``ValidationResult``, which carries whether the check passed, a message, and an optional free-form ``diagnostics`` dictionary.
+* ``importance`` -- every validator is constructed with ``importance="warn"`` or ``importance="fail"``, which determines what happens when the check fails (see below).
+
+To apply it, pass validator *instances* to ``@check_output_custom``. You can pass multiple validators to a single decorator; note that you cannot stack ``@check_output_custom`` decorators on one function.
+
+.. code-block:: python
+
+    # my_module.py (continued)
+    from hamilton.function_modifiers import check_output_custom
+
+
+    @check_output_custom(AllPositiveValidator(importance="warn"))
+    def prices_with_tax(prices: pd.Series, tax_rate: float) -> pd.Series:
+        return prices * (1 + tax_rate)
+
+At runtime, each validator runs on the function's output:
+
+* With ``importance="warn"``, a failed check logs a warning (via the standard Python ``logging`` module) and execution continues.
+* With ``importance="fail"``, a failed check raises ``hamilton.data_quality.base.DataValidationError``. All validators on the function are evaluated first, so the error reports every failure at once.
+
+Under the hood, the decorator splits the function into several nodes: ``prices_with_tax_raw`` (the original function), one node per validator (named ``{function_name}_{validator_name}``, e.g. ``prices_with_tax_all_positive_validator``), and a final ``prices_with_tax`` node that acts on the validation results and returns the original output. The validator nodes are tagged with ``hamilton.data_quality.contains_dq_results`` (and ``hamilton.data_quality.source_node`` naming the node they validate), so you can locate them programmatically -- or simply request them as outputs to inspect the ``ValidationResult``:
+
+.. code-block:: python
+
+    # run.py
+    import logging
+    import sys
+
+    import pandas as pd
+
+    from hamilton import driver
+
+    import my_module
+
+    logging.basicConfig(stream=sys.stdout)  # so "warn" importance warnings are visible
+
+    dr = driver.Builder().with_modules(my_module).build()
+    results = dr.execute(
+        ["prices_with_tax", "prices_with_tax_all_positive_validator"],
+        inputs={"prices": pd.Series([10.0, 20.0, -5.0]), "tax_rate": 0.1},
+    )
+    print(results["prices_with_tax_all_positive_validator"])
+    # ValidationResult(passes=False, message='Found 1 negative value(s).', ...)
+
+If pandas series validation like the above is your main use case, also consider the pandera integration shown in example 2 above -- ``@check_output(schema=...)`` lets you express many checks declaratively without writing a validator class.
+
 Async validators
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Closes [#212 ](https://github.com/apache/hamilton/issues/212) - adds documentation for `@check_output_custom`

It walks through the full lifecycle of a custom validator:

- **When you need one**: positions `@check_output_custom` relative to `@check_output`'s default validators (data type, range, allowed values, ...), with a cross-reference to the `check_output` API reference.
- **Writing the validator**: a complete example class, `AllPositiveValidator`, that subclasses `hamilton.data_quality.base.DataValidator` and checks a pandas Series for negative values. Each required method is then explained individually: `applies_to`, `description`, `name`, `validate` returning a `ValidationResult` (with `passes`, `message`, and the free-form `diagnostics` dict), plus the `importance` constructor argument.
- **Applying it**: decorating a function with a validator *instance*, including that multiple validators go into a single decorator call and that stacking `@check_output_custom` decorators is not supported.
- **Runtime semantics**: `importance="warn"` logs through the standard `logging` module and continues; `importance="fail"` raises `DataValidationError`, with all validators evaluated first so every failure is reported at once.
- **What happens to the DAG**: the `{name}_raw` / per-validator / final-node split, the `hamilton.data_quality.contains_dq_results` and `hamilton.data_quality.source_node` tags, and a driver example showing that validator nodes can simply be requested as outputs to inspect their `ValidationResult`.

## Changes

Adds a "Custom validators" section to the "Data quality" how-to page (`docs/how-tos/run-data-quality-checks.rst`) covering:
- when to write a custom validator vs. using `@check_output`'s built-in validators
- a complete, runnable `DataValidator` subclass example
- applying one or more validator instances with `@check_output_custom` (and that decorators can't be stacked)
- runtime behavior of `importance="warn"` (logs, continues) vs `"fail"` (raises `DataValidationError`)
- how validation results appear as tagged nodes in the DAG and how to request them as outputs

## How I tested this

- Ran every code snippet in the section against a local editable install; outputs match the docs verbatim.
- Built the docs locally with `sphinx-build -b dirhtml -W`; no warnings from the changed page.
- Screenshot of the rendered section attached.
<img width="1400" height="3200" alt="image" src="https://github.com/user-attachments/assets/dff6d44b-48de-4fdb-a09c-8b438392ab18" />

## Notes

- Docs-only change

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested (n/a - docs only)
- [ ] New functions are documented (n/a - docs only)
- [ ] Placeholder code is flagged / future TODOs are captured in comments (n/a)
- [x] Project documentation has been updated if adding/changing functionality.