### PR TITLE
Show the result builder as a node in the Hamilton UI

### DIFF
--- a/ui/frontend/src/components/dashboard/Visualize/DAGRun.tsx
+++ b/ui/frontend/src/components/dashboard/Visualize/DAGRun.tsx
@@ -58,6 +58,9 @@ export const ExecutionNodeComponent = (props: {
       item.nodeTemplate.classifications.includes("input")
     )
     .some((i) => i);
+  const isResultBuilder = props.data.nodes.some((item) =>
+    item.nodeTemplate.classifications.includes("result_builder")
+  );
   const hidden = props.data.collapsed;
 
   const { vertical } = useContext(NodeControlContext);
@@ -103,7 +106,9 @@ export const ExecutionNodeComponent = (props: {
     <div
       className={`group flex flex-col gap-3 items-center cursor-cell bg-opacity-0 ${text} ${
         isSelected ? "opacity-80" : ""
-      } ${hasArtifact ? "border border-dashed " : " "} rounded-lg ${background}
+      } ${
+        hasArtifact || isResultBuilder ? "border border-dashed " : " "
+      } ${isResultBuilder ? "border-2" : ""} rounded-lg ${background}
       ${isInput ? " border-2 border-dwdarkblue/50 p-0" : " text-white p-1"}`}
     >
       {artifactTypes.size > 0 ? (

--- a/ui/frontend/src/components/dashboard/Visualize/DAGViz.tsx
+++ b/ui/frontend/src/components/dashboard/Visualize/DAGViz.tsx
@@ -70,6 +70,7 @@ import {
   nodeKey,
 } from "./utils";
 import { getAdapterIcon } from "../../../utils";
+import { PiStackBold } from "react-icons/pi";
 import {
   GROUPING_FUNCTION_OPTIONS,
   NodeHierarchyManager,
@@ -608,6 +609,9 @@ const BaseNodeComponent = (props: {
       item.nodeTemplate.classifications.includes("input")
     )
     .some((i) => i);
+  const isResultBuilder = props.data.nodes.some((item) =>
+    item.nodeTemplate.classifications.includes("result_builder")
+  );
   const isExternalToSubdag = props.data.nodes
     .map((item) =>
       item.nodeTemplate.classifications.includes("external_to_subdag")
@@ -666,7 +670,7 @@ const BaseNodeComponent = (props: {
       className={`${
         highlightedContext.inSelectedDAG ? "" : "opacity-20"
       } group flex flex-col gap-3 items-center cursor-cell ${
-        hasArtifact ? "border border-dashed " : " "
+        hasArtifact || isResultBuilder ? "border border-dashed " : " "
       } rounded-lg p-1 ${
         displayAnything ? "" : "invisible"
       } ${outlineColorClasses} ${backgroundHoverClasses}`}
@@ -690,6 +694,13 @@ const BaseNodeComponent = (props: {
             );
           })}
         </div>
+      ) : (
+        <></>
+      )}
+      {isResultBuilder ? (
+        <PiStackBold
+          className={`text-5xl group-hover:text-opacity-80 ${iconClasses}`}
+        />
       ) : (
         <></>
       )}
@@ -821,6 +832,9 @@ const FunctionNodeComponent = (props: {
       item.nodeTemplate.classifications.includes("input")
     )
     .some((i) => i);
+  const isResultBuilder = props.data.nodes.some((item) =>
+    item.nodeTemplate.classifications.includes("result_builder")
+  );
   const hidden = props.data.collapsed;
   const {
     upstreamNodes,
@@ -870,7 +884,7 @@ const FunctionNodeComponent = (props: {
       className={`${
         highlightedContext.inSelectedDAG ? "" : "opacity-20"
       } group flex flex-col gap-3 items-center cursor-cell ${
-        hasArtifact ? "border border-dashed " : " "
+        hasArtifact || isResultBuilder ? "border border-dashed " : " "
       } rounded-lg p-1 ${
         displayAnything ? "" : "invisible"
       } ${outlineColorClasses} ${backgroundHoverClasses}`}
@@ -894,6 +908,13 @@ const FunctionNodeComponent = (props: {
             );
           })}
         </div>
+      ) : (
+        <></>
+      )}
+      {isResultBuilder ? (
+        <PiStackBold
+          className={`text-5xl group-hover:text-opacity-80 ${iconClasses}`}
+        />
       ) : (
         <></>
       )}

--- a/ui/frontend/src/components/dashboard/Visualize/Legend.tsx
+++ b/ui/frontend/src/components/dashboard/Visualize/Legend.tsx
@@ -28,6 +28,11 @@ export const Legend = () => {
       text: "Input",
       bgClass: "bg-white text-dwdarkblue border-2 border-dwdarkblue",
     },
+    {
+      // matches the node rendering: dashed border in the default border color
+      text: "Result Builder",
+      bgClass: "bg-dwdarkblue text-white border-2 border-dashed",
+    },
   ];
 
   return (

--- a/ui/frontend/src/state/api/friendlyApi.ts
+++ b/ui/frontend/src/state/api/friendlyApi.ts
@@ -137,7 +137,8 @@ export type Classification =
   | "artifact"
   | "data_loader"
   | "data_saver"
-  | "input";
+  | "input"
+  | "result_builder";
 
 const codeVersionTypeMap = {
   CodeVersionGit1: { version: 1, type: "git" },

--- a/ui/sdk/src/hamilton_sdk/adapters.py
+++ b/ui/sdk/src/hamilton_sdk/adapters.py
@@ -56,6 +56,64 @@ def get_node_name(node_: node.Node, task_id: Optional[str]) -> str:
 LONG_SCALE = float(0xFFFFFFFFFFFFFFF)
 
 
+def _failed_result_summary() -> dict:
+    """Returns a fresh placeholder summary for results that could not be processed.
+
+    A fresh dict each call -- callers assign it to per-run state, so a shared
+    module-level constant would alias across runs.
+
+    @return: An observability summary dict marking the result as unprocessable.
+    """
+    return {
+        "observability_type": "observability_failure",
+        "observability_schema_version": "0.0.3",
+        "observability_value": {
+            "type": str(str),
+            "value": "Failed to process result.",
+        },
+    }
+
+
+def _make_result_attributes(
+    node_name: str, result_summary: dict | None, other_results: list[dict]
+) -> list[dict]:
+    """Shapes process_result output into update_tasks attributes.
+
+    `result_summary` comes first because the order influences UI display order.
+
+    @param node_name: Name of the node the attributes belong to.
+    @param result_summary: Primary observability summary, or None if processing failed.
+    @param other_results: Additional observability dicts (schema, extra attributes).
+    @return: A list of attribute dicts for client.update_tasks.
+    """
+    if result_summary is None:
+        result_summary = _failed_result_summary()
+    attributes = [
+        dict(
+            node_name=node_name,
+            name="result_summary",
+            type=result_summary["observability_type"],
+            # 0.0.3 -> 3
+            schema_version=int(result_summary["observability_schema_version"].split(".")[-1]),
+            value=result_summary["observability_value"],
+            attribute_role="result_summary",
+        )
+    ]
+    for i, other_result in enumerate(other_results):
+        attributes.append(
+            dict(
+                node_name=node_name,
+                name=other_result.get("name", f"Attribute {i + 1}"),  # retrieve name if specified
+                type=other_result["observability_type"],
+                # 0.0.3 -> 3
+                schema_version=int(other_result["observability_schema_version"].split(".")[-1]),
+                value=other_result["observability_value"],
+                attribute_role="result_summary",
+            )
+        )
+    return attributes
+
+
 class HamiltonTracker(
     base.BasePostGraphConstruct,
     base.BasePreGraphExecute,
@@ -120,6 +178,8 @@ class HamiltonTracker(
         self.tracking_states = {}
         self.dw_run_ids = {}
         self.task_runs = {}
+        self.result_builder_nodes = {}  # fg_id -> synthetic node (or None if no builder)
+        self.run_final_vars = {}  # run_id -> final_vars, for realized_dependencies
         super().__init__()
         # set this to a float to sample blocks. 0.1 means 10% of blocks will be sampled.
         # set this to an int to sample blocks by modulo.
@@ -140,6 +200,10 @@ class HamiltonTracker(
             self.seed = random.random()
         logger.debug("post_graph_construct")
         fg_id = id(graph)
+        builder = driver._get_result_builder(graph)
+        self.result_builder_nodes[fg_id] = (
+            driver._create_result_builder_node(builder) if builder is not None else None
+        )
         if fg_id in self.dag_template_id_cache:
             logger.warning("Skipping creation of DAG template as it already exists.")
             return
@@ -147,12 +211,15 @@ class HamiltonTracker(
         vcs_info = driver._derive_version_control_info(module_hash)
         dag_hash = driver.hash_dag(graph)
         code_hash = driver.hash_dag_modules(graph, modules)
+        nodes = driver._extract_node_templates_from_function_graph(graph)
+        if self.result_builder_nodes[fg_id] is not None:
+            nodes.append(driver._extract_node_template(self.result_builder_nodes[fg_id]))
         dag_template_id = self.client.register_dag_template_if_not_exists(
             project_id=self.project_id,
             dag_hash=dag_hash,
             code_hash=code_hash,
             name=self.dag_name,
-            nodes=driver._extract_node_templates_from_function_graph(graph),
+            nodes=nodes,
             code_artifacts=driver.extract_code_artifacts_from_function_graph(
                 graph, vcs_info, vcs_info.local_repo_base_path
             ),
@@ -189,6 +256,7 @@ class HamiltonTracker(
         )
         self.dw_run_ids[run_id] = dw_run_id
         self.task_runs[run_id] = {}
+        self.run_final_vars[run_id] = list(final_vars)
         logger.warning(
             f"\nCapturing execution run. Results can be found at "
             f"{self.hamilton_ui_url}/dashboard/project/{self.project_id}/runs/{dw_run_id}\n"
@@ -287,35 +355,18 @@ class HamiltonTracker(
         tracking_state = self.tracking_states[run_id]
         task_run.end_time = datetime.datetime.now(UTC)
 
-        other_results = []
         if success:
             task_run.status = Status.SUCCESS
             task_run.result_type = type(result)
             result_summary, schema, additional_attributes = runs.process_result(result, node_)
             if result_summary is None:
-                result_summary = {
-                    "observability_type": "observability_failure",
-                    "observability_schema_version": "0.0.3",
-                    "observability_value": {
-                        "type": str(str),
-                        "value": "Failed to process result.",
-                    },
-                }
+                result_summary = _failed_result_summary()
             other_results = ([schema] if schema is not None else []) + additional_attributes
-
             task_run.result_summary = result_summary
-            task_attr = dict(
-                node_name=get_node_name(node_, task_id),
-                name="result_summary",
-                type=task_run.result_summary["observability_type"],
-                # 0.0.3 -> 3
-                schema_version=int(
-                    task_run.result_summary["observability_schema_version"].split(".")[-1]
-                ),
-                value=task_run.result_summary["observability_value"],
-                attribute_role="result_summary",
+            # `result_summary` is first because the order influences UI display order
+            attributes = _make_result_attributes(
+                get_node_name(node_, task_id), result_summary, other_results
             )
-
         else:
             task_run.status = Status.FAILURE
             task_run.is_in_sample = True  # override any sampling
@@ -323,30 +374,18 @@ class HamiltonTracker(
                 task_run.error = runs.serialize_data_quality_error(error)
             else:
                 task_run.error = traceback.format_exception(type(error), error, error.__traceback__)
-            task_attr = dict(
-                node_name=get_node_name(node_, task_id),
-                name="stack_trace",
-                type="error",
-                schema_version=1,
-                value={
-                    "stack_trace": task_run.error,
-                },
-                attribute_role="error",
-            )
-
-        # `result_summary` or "error" is first because the order influences UI display order
-        attributes = [task_attr]
-        for i, other_result in enumerate(other_results):
-            other_attr = dict(
-                node_name=get_node_name(node_, task_id),
-                name=other_result.get("name", f"Attribute {i + 1}"),  # retrieve name if specified
-                type=other_result["observability_type"],
-                # 0.0.3 -> 3
-                schema_version=int(other_result["observability_schema_version"].split(".")[-1]),
-                value=other_result["observability_value"],
-                attribute_role="result_summary",
-            )
-            attributes.append(other_attr)
+            attributes = [
+                dict(
+                    node_name=get_node_name(node_, task_id),
+                    name="stack_trace",
+                    type="error",
+                    schema_version=1,
+                    value={
+                        "stack_trace": task_run.error,
+                    },
+                    attribute_role="error",
+                )
+            ]
         tracking_state.update_task(node_.name, task_run)
         task_update = dict(
             node_template_name=node_.name,
@@ -394,6 +433,44 @@ class HamiltonTracker(
                 if task_run.end_time is None and task_run.status == Status.SUCCESS:
                     task_run.end_time = finally_block_time
 
+        builder_node = self.result_builder_nodes.get(id(graph))
+        # `execute()` fires this hook after do_build_result, so `results` is the combined
+        # built object. Deprecated raw_execute()/materialize() paths fire it with the raw
+        # node dict without ever running the builder -- the type check skips those so we
+        # don't report a builder execution that never happened.
+        if (
+            builder_node is not None
+            and success
+            and results is not None
+            and (not isinstance(builder_node.type, type) or isinstance(results, builder_node.type))
+        ):
+            try:
+                now = datetime.datetime.now(UTC)
+                result_summary, schema, additional = runs.process_result(results, builder_node)
+                attributes = _make_result_attributes(
+                    builder_node.name,
+                    result_summary,
+                    ([schema] if schema is not None else []) + additional,
+                )
+                task_update = dict(
+                    node_template_name=builder_node.name,
+                    node_name=builder_node.name,  # no task_id at the graph level
+                    realized_dependencies=self.run_final_vars.get(run_id, []),
+                    status=Status.SUCCESS,
+                    # builder duration is not observable from this hook
+                    start_time=now,
+                    end_time=now,
+                )
+                self.client.update_tasks(
+                    dw_run_id,
+                    attributes=attributes,
+                    task_updates=[task_update for _ in attributes],
+                    in_samples=[True for _ in attributes],
+                )
+            except Exception:
+                # tracking must never fail the user's run
+                logger.warning("Failed to track result builder output.", exc_info=True)
+
         self.client.log_dag_run_end(
             dag_run_id=dw_run_id,
             status=tracking_state.status.value,
@@ -439,6 +516,8 @@ class AsyncHamiltonTracker(
         self.tracking_states = {}
         self.dw_run_ids = {}
         self.task_runs = {}
+        self.result_builder_nodes = {}  # fg_id -> synthetic node (or None if no builder)
+        self.run_final_vars = {}  # run_id -> final_vars, for realized_dependencies
         self.initialized = False
         super().__init__()
 
@@ -474,6 +553,10 @@ class AsyncHamiltonTracker(
     ):
         logger.debug("post_graph_construct")
         fg_id = id(graph)
+        builder = driver._get_result_builder(graph)
+        self.result_builder_nodes[fg_id] = (
+            driver._create_result_builder_node(builder) if builder is not None else None
+        )
         if fg_id in self.dag_template_id_cache:
             logger.warning("Skipping creation of DAG template as it already exists.")
             return
@@ -481,12 +564,15 @@ class AsyncHamiltonTracker(
         vcs_info = driver._derive_version_control_info(module_hash)
         dag_hash = driver.hash_dag(graph)
         code_hash = driver.hash_dag_modules(graph, modules)
+        nodes = driver._extract_node_templates_from_function_graph(graph)
+        if self.result_builder_nodes[fg_id] is not None:
+            nodes.append(driver._extract_node_template(self.result_builder_nodes[fg_id]))
         dag_template_id = await self.client.register_dag_template_if_not_exists(
             project_id=self.project_id,
             dag_hash=dag_hash,
             code_hash=code_hash,
             name=self.dag_name,
-            nodes=driver._extract_node_templates_from_function_graph(graph),
+            nodes=nodes,
             code_artifacts=driver.extract_code_artifacts_from_function_graph(
                 graph, vcs_info, vcs_info.local_repo_base_path
             ),
@@ -523,6 +609,7 @@ class AsyncHamiltonTracker(
         )
         self.dw_run_ids[run_id] = dw_run_id
         self.task_runs[run_id] = {}
+        self.run_final_vars[run_id] = list(final_vars)
 
     async def pre_node_execute(
         self, run_id: str, node_: node.Node, kwargs: dict[str, Any], task_id: Optional[str] = None
@@ -567,7 +654,6 @@ class AsyncHamiltonTracker(
         task_run = self.task_runs[run_id][node_.name]
         tracking_state = self.tracking_states[run_id]
         task_run.end_time = datetime.datetime.now(UTC)
-        other_results = []
 
         if success:
             task_run.status = Status.SUCCESS
@@ -575,25 +661,11 @@ class AsyncHamiltonTracker(
             result_summary, schema, additional = runs.process_result(result, node_)  # add node
             other_results = ([schema] if schema is not None else []) + additional
             if result_summary is None:
-                result_summary = {
-                    "observability_type": "observability_failure",
-                    "observability_schema_version": "0.0.3",
-                    "observability_value": {
-                        "type": str(str),
-                        "value": "Failed to process result.",
-                    },
-                }
+                result_summary = _failed_result_summary()
             task_run.result_summary = result_summary
-            task_attr = dict(
-                node_name=get_node_name(node_, task_id),
-                name="result_summary",
-                type=task_run.result_summary["observability_type"],
-                # 0.0.3 -> 3
-                schema_version=int(
-                    task_run.result_summary["observability_schema_version"].split(".")[-1]
-                ),
-                value=task_run.result_summary["observability_value"],
-                attribute_role="result_summary",
+            # `result_summary` is first because the order influences UI display order
+            attributes = _make_result_attributes(
+                get_node_name(node_, task_id), result_summary, other_results
             )
         else:
             task_run.status = Status.FAILURE
@@ -601,29 +673,18 @@ class AsyncHamiltonTracker(
                 task_run.error = runs.serialize_data_quality_error(error)
             else:
                 task_run.error = traceback.format_exception(type(error), error, error.__traceback__)
-            task_attr = dict(
-                node_name=get_node_name(node_, task_id),
-                name="stack_trace",
-                type="error",
-                schema_version=1,
-                value={
-                    "stack_trace": task_run.error,
-                },
-                attribute_role="error",
-            )
-
-        attributes = [task_attr]
-        for i, other_result in enumerate(other_results):
-            other_attr = dict(
-                node_name=get_node_name(node_, task_id),
-                name=other_result.get("name", f"Attribute {i + 1}"),  # retrieve name if specified
-                type=other_result["observability_type"],
-                # 0.0.3 -> 3
-                schema_version=int(other_result["observability_schema_version"].split(".")[-1]),
-                value=other_result["observability_value"],
-                attribute_role="result_summary",
-            )
-            attributes.append(other_attr)
+            attributes = [
+                dict(
+                    node_name=get_node_name(node_, task_id),
+                    name="stack_trace",
+                    type="error",
+                    schema_version=1,
+                    value={
+                        "stack_trace": task_run.error,
+                    },
+                    attribute_role="error",
+                )
+            ]
         tracking_state.update_task(get_node_name(node_, task_id), task_run)
         task_update = dict(
             node_template_name=node_.name,
@@ -668,6 +729,32 @@ class AsyncHamiltonTracker(
                         task_run.error = ["Run was likely aborted."]
                 if task_run.end_time is None and task_run.status == Status.SUCCESS:
                     task_run.end_time = finally_block_time
+
+        builder_node = self.result_builder_nodes.get(id(graph))
+        if builder_node is not None and success:
+            # Unlike the sync driver, the async driver fires this hook *before*
+            # do_build_result (async_driver.py raw_execute finally vs execute), so
+            # `results` here is the raw dict -- emit a status-only update, no summary.
+            try:
+                now = datetime.datetime.now(UTC)
+                task_update = dict(
+                    node_template_name=builder_node.name,
+                    node_name=builder_node.name,  # no task_id at the graph level
+                    realized_dependencies=self.run_final_vars.get(run_id, []),
+                    status=Status.SUCCESS,
+                    # builder duration is not observable from this hook
+                    start_time=now,
+                    end_time=now,
+                )
+                await self.client.update_tasks(
+                    dw_run_id,
+                    attributes=[None],
+                    task_updates=[task_update],
+                    in_samples=[True],
+                )
+            except Exception:
+                # tracking must never fail the user's run
+                logger.warning("Failed to track result builder output.", exc_info=True)
 
         # TODO: only update things that have changed?
         # self.client.update_tasks(

--- a/ui/sdk/src/hamilton_sdk/driver.py
+++ b/ui/sdk/src/hamilton_sdk/driver.py
@@ -507,9 +507,58 @@ def _convert_node_dependencies(node: Node) -> dict:
     }
 
 
+RESULT_BUILDER_NODE_NAME = "__result_builder"
+
+
+def _get_result_builder(fn_graph: graph.FunctionGraph) -> Any | None:
+    """Returns the result builder attached to the graph's adapter set, else None.
+
+    Handles both modern builders (which implement ``do_build_result`` directly) and
+    legacy ones wrapped in a ``SimplePythonGraphAdapter`` (unwrapped via ``.result_builder``).
+
+    @param fn_graph: Function graph whose adapter set to inspect.
+    @return: The result builder instance, or None if none is attached.
+    """
+    adapter = getattr(fn_graph, "adapter", None)
+    if adapter is None:
+        return None
+    for a in getattr(adapter, "adapters", []):
+        if hasattr(a, "do_build_result"):
+            return getattr(a, "result_builder", a)
+    return None
+
+
+def _create_result_builder_node(builder: Any) -> Node:
+    """Synthesizes a node representing the result builder's combined output.
+
+    The builder is not a real graph node (core runs it as a post-step after
+    ``raw_execute``), so we fabricate one for tracking purposes. Dependencies are
+    empty at template time -- final_vars are only known per-run, and get reported
+    via ``realized_dependencies`` on the task update.
+
+    @param builder: The result builder instance to represent.
+    @return: A synthetic Node tagged ``hamilton.result_builder``.
+    """
+    output_type = Any
+    if hasattr(builder, "output_type"):
+        try:
+            output_type = builder.output_type()
+        except Exception:
+            pass
+    return Node(
+        name=RESULT_BUILDER_NODE_NAME,
+        typ=output_type if output_type is not None else Any,
+        doc_string=f"Combined output built by {type(builder).__name__}.",
+        input_types={},  # synthetic node has no callable to introspect
+        tags={"hamilton.result_builder": type(builder).__name__},
+    )
+
+
 def _convert_classifications(node_: Node) -> list[str]:
     out = []
-    if (
+    if node_.tags.get("hamilton.result_builder"):
+        out.append("result_builder")
+    elif (
         node_.tags.get("hamilton.data_loader")
         and node_.tags.get("hamilton.data_loader.has_metadata") is not False
     ):
@@ -523,39 +572,37 @@ def _convert_classifications(node_: Node) -> list[str]:
     return out
 
 
+def _extract_node_template(node_: Node) -> dict:
+    """Converts a single node to the template dict the DAGWorks graph can understand.
+
+    @param node_: Node to convert.
+    @return: A node template dict.
+    """
+    code_artifact_pointers = (
+        []
+        if (node_.originating_functions is None or len(node_.originating_functions) == 0)
+        else [_get_fully_qualified_function_path(fn) for fn in node_.originating_functions]
+    )
+    return dict(
+        name=node_.name,
+        output={"type_name": str(node_.type)},
+        output_type="python_type",
+        output_schema_version=1,  # TODO -- merge this with _convert_node_dependencies
+        documentation=node_.documentation,
+        tags=node_.tags,  # TODO -- ensure serializable
+        classifications=_convert_classifications(node_),  # TODO -- manage classifications
+        code_artifact_pointers=code_artifact_pointers,
+        **_convert_node_dependencies(node_),
+    )
+
+
 def _extract_node_templates_from_function_graph(fn_graph: graph.FunctionGraph) -> list[dict]:
     """Converts a function graph to a list of nodes that the DAGWorks graph can understand.
 
     @param fn: Function graph to convert
     @return: A list of node objects
     """
-    node_templates = []
-    for node_ in fn_graph.nodes.values():
-        code_artifact_pointers = (
-            []
-            if (node_.originating_functions is None or len(node_.originating_functions) == 0)
-            else [_get_fully_qualified_function_path(fn) for fn in node_.originating_functions]
-        )
-        node_templates.append(
-            dict(
-                name=node_.name,
-                output={"type_name": str(node_.type)},
-                output_type="python_type",
-                output_schema_version=1,  # TODO -- merge this with _convert_node_dependencies
-                documentation=node_.documentation,
-                tags=node_.tags,  # TODO -- ensure serializable
-                classifications=_convert_classifications(node_),  # TODO -- manage classifications
-                code_artifact_pointers=(
-                    code_artifact_pointers
-                    if node_.originating_functions is None or len(node_.originating_functions) == 0
-                    else [
-                        _get_fully_qualified_function_path(fn) for fn in node_.originating_functions
-                    ]
-                ),
-                **_convert_node_dependencies(node_),
-            )
-        )
-    return node_templates
+    return [_extract_node_template(node_) for node_ in fn_graph.nodes.values()]
 
 
 def _derive_url(vcs_info: GitInfo, path: str, line: int) -> str:

--- a/ui/sdk/tests/test_result_builder_tracking.py
+++ b/ui/sdk/tests/test_result_builder_tracking.py
@@ -1,0 +1,264 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for https://github.com/apache/hamilton/issues/1150.
+
+The result builder is not a graph node -- the sync driver runs it after
+``raw_execute`` -- so the UI never showed the combined object ``execute()``
+returns. The HamiltonTracker now synthesizes a ``__result_builder`` node
+(classified ``result_builder``) and reports the built result as its output.
+"""
+
+import asyncio
+import functools
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from hamilton import async_driver, base
+from hamilton import driver as h_driver
+from hamilton_sdk import adapters
+from hamilton_sdk.api import clients
+from hamilton_sdk.api.projecttypes import GitInfo
+from hamilton_sdk.driver import RESULT_BUILDER_NODE_NAME
+
+import tests.resources.basic_dag_with_config
+from tests.test_tracking import MockHamiltonClient
+
+
+def _make_driver(dag_name: str, with_result_builder: bool = True) -> h_driver.Driver:
+    tracker = adapters.HamiltonTracker(
+        project_id=1,
+        username="repro@example.com",
+        dag_name=dag_name,
+        client_factory=MockHamiltonClient,
+        api_key="foo",
+    )
+    extra_adapters = [base.DictResult()] if with_result_builder else []
+    return (
+        h_driver.Builder()
+        .with_config({"foo": "baz"})  # selects b__2 (a + 2); with a=1 -> b=3, c=6
+        .with_modules(tests.resources.basic_dag_with_config)
+        .with_adapters(tracker, *extra_adapters)
+        .build()
+    )
+
+
+def _registered_nodes(client: MockHamiltonClient) -> dict[str, list[str]]:
+    """name -> classifications for the node list the tracker registered."""
+    nodes = client.register_dag_template_if_not_exists_latest_kwargs["nodes"]
+    return {n["name"]: n.get("classifications", []) for n in nodes}
+
+
+def _client(dr: h_driver.Driver) -> MockHamiltonClient:
+    (tracker,) = [a for a in dr.adapter.adapters if isinstance(a, adapters.HamiltonTracker)]
+    return tracker.client
+
+
+def test_result_builder_node_is_tracked():
+    dr = _make_driver("repro-execute")
+    result = dr.execute(final_vars=["b", "c"], inputs={"a": 1})
+    assert result == {"b": 3, "c": 6}
+    client = _client(dr)
+
+    # the synthetic node is registered in the DAG template, correctly classified
+    nodes = _registered_nodes(client)
+    assert RESULT_BUILDER_NODE_NAME in nodes
+    assert nodes[RESULT_BUILDER_NODE_NAME] == ["result_builder"]
+
+    # the combined result is reported as that node's output: the builder update is
+    # the last update_tasks call (it happens right before log_dag_run_end)
+    last = client.update_tasks_latest_kwargs
+    task_update = last["task_updates"][0]
+    assert task_update["node_template_name"] == RESULT_BUILDER_NODE_NAME
+    assert task_update["realized_dependencies"] == ["b", "c"]
+    assert task_update["status"].value == "SUCCESS"
+    assert last["attributes"][0]["name"] == "result_summary"
+
+
+def test_no_result_builder_no_synthetic_node():
+    dr = _make_driver("repro-no-builder", with_result_builder=False)
+    dr.execute(final_vars=["b", "c"], inputs={"a": 1})
+    client = _client(dr)
+
+    nodes = _registered_nodes(client)
+    assert RESULT_BUILDER_NODE_NAME not in nodes
+    # the last update_tasks call is a normal node update, not a builder one
+    last = client.update_tasks_latest_kwargs
+    assert last["task_updates"][0]["node_template_name"] != RESULT_BUILDER_NODE_NAME
+
+
+def test_failed_run_emits_no_builder_update():
+    dr = _make_driver("repro-failure")
+    with pytest.raises(ValueError):
+        # missing required input "a" -> execution fails
+        dr.execute(final_vars=["b", "c"], inputs={})
+    client = _client(dr)
+
+    last = getattr(client, "update_tasks_latest_kwargs", None)
+    if last is not None:  # nothing may have run at all
+        assert last["task_updates"][0]["node_template_name"] != RESULT_BUILDER_NODE_NAME
+    assert client.log_dag_run_end_latest_kwargs["status"] == "FAILURE"
+
+
+class _StrResult(base.DictResult):
+    """Builder whose output type (str) differs from the raw node dict."""
+
+    @staticmethod
+    def build_result(**outputs):
+        return str(outputs)
+
+    def output_type(self):
+        return str
+
+
+def test_raw_execute_emits_no_builder_update():
+    """Deprecated raw_execute() never runs the builder -- the tracker must not
+    report a builder execution (it only sees the raw node dict)."""
+    tracker = adapters.HamiltonTracker(
+        project_id=1,
+        username="repro@example.com",
+        dag_name="repro-raw-execute",
+        client_factory=MockHamiltonClient,
+        api_key="foo",
+    )
+    dr = (
+        h_driver.Builder()
+        .with_config({"foo": "baz"})
+        .with_modules(tests.resources.basic_dag_with_config)
+        .with_adapters(tracker, _StrResult())
+        .build()
+    )
+
+    dr.raw_execute(["b", "c"], inputs={"a": 1})  # logs a deprecation warning
+    last = tracker.client.update_tasks_latest_kwargs
+    assert last["task_updates"][0]["node_template_name"] != RESULT_BUILDER_NODE_NAME
+
+    # sanity check: the same driver's execute() path does report the builder
+    result = dr.execute(final_vars=["b", "c"], inputs={"a": 1})
+    assert isinstance(result, str)
+    last = tracker.client.update_tasks_latest_kwargs
+    assert last["task_updates"][0]["node_template_name"] == RESULT_BUILDER_NODE_NAME
+
+
+# Same trick as tests.test_tracking.track_calls, for async methods.
+def track_async_calls(fn: Callable):
+    @functools.wraps(fn)
+    async def wrapper(self, *args, **kwargs):
+        setattr(self, f"{fn.__name__}_latest_kwargs", kwargs)
+        setattr(self, f"{fn.__name__}_latest_args", args)
+        setattr(self, f"{fn.__name__}_call_count", getattr(fn, "call_count", 0) + 1)
+        return await fn(self, *args, **kwargs)
+
+    return wrapper
+
+
+class MockAsyncHamiltonClient(clients.BasicAsynchronousHamiltonClient):
+    """Basic no-op async Hamilton client, mirroring MockHamiltonClient."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @track_async_calls
+    async def ainit(self):
+        pass
+
+    @track_async_calls
+    async def validate_auth(self):
+        pass
+
+    @track_async_calls
+    async def project_exists(self, project_id: int) -> bool:
+        return True
+
+    @track_async_calls
+    async def register_dag_template_if_not_exists(
+        self,
+        project_id: int,
+        dag_hash: str,
+        code_hash: str,
+        nodes: list[dict],
+        code_artifacts: list[dict],
+        name: str,
+        config: dict,
+        tags: dict[str, Any],
+        code: list[dict],
+        vcs_info: GitInfo,
+    ):
+        return 1
+
+    @track_async_calls
+    async def create_and_start_dag_run(
+        self, dag_template_id: int, tags: dict[str, str], inputs: dict[str, Any], outputs: list[str]
+    ) -> int:
+        return 100
+
+    @track_async_calls
+    async def update_tasks(
+        self,
+        dag_run_id: int,
+        attributes: list[dict],
+        task_updates: list[dict],
+        in_samples: list[bool] = None,
+    ):
+        pass
+
+    @track_async_calls
+    async def log_dag_run_end(self, dag_run_id: int, status: str):
+        pass
+
+
+async def _execute_async(dag_name: str) -> tuple[MockAsyncHamiltonClient, dict]:
+    tracker = adapters.AsyncHamiltonTracker(
+        project_id=1,
+        username="repro@example.com",
+        dag_name=dag_name,
+        client_factory=MockAsyncHamiltonClient,
+        api_key="foo",
+    )
+    await tracker.ainit()
+    dr = await (
+        async_driver.Builder()
+        .with_config({"foo": "baz"})
+        .with_modules(tests.resources.basic_dag_with_config)
+        .with_adapters(tracker, base.DictResult())
+        .build()
+    )
+    result = await dr.execute(final_vars=["b", "c"], inputs={"a": 1})
+    return tracker.client, result
+
+
+def test_async_result_builder_node_is_tracked():
+    client, result = asyncio.run(_execute_async("repro-async-execute"))
+    assert result == {"b": 3, "c": 6}
+
+    # the synthetic node is registered in the DAG template, correctly classified
+    nodes = _registered_nodes(client)
+    assert RESULT_BUILDER_NODE_NAME in nodes
+    assert nodes[RESULT_BUILDER_NODE_NAME] == ["result_builder"]
+
+    # the async driver fires post_graph_execute *before* do_build_result, so the
+    # tracker can only report a status-only update (no result summary) -- it is
+    # still the last update_tasks call, right before log_dag_run_end
+    last = client.update_tasks_latest_kwargs
+    task_update = last["task_updates"][0]
+    assert task_update["node_template_name"] == RESULT_BUILDER_NODE_NAME
+    assert task_update["realized_dependencies"] == ["b", "c"]
+    assert task_update["status"].value == "SUCCESS"
+    assert last["attributes"] == [None]
+    assert client.log_dag_run_end_latest_kwargs["status"] == "SUCCESS"


### PR DESCRIPTION
Implements #1150: the result builder (`DictResult`, `PandasDataFrameResult`, ...) combines the outputs of `execute()` into the single returned object, but it was never shown in the UI. This makes it visible, using an SDK-side approach.

## Changes

**SDK (`ui/sdk`)**
- `HamiltonTracker` detects an attached result builder (modern builders and legacy `SimplePythonGraphAdapter`-wrapped ones), synthesizes a `__result_builder` node classified `result_builder`, and registers it with the DAG template at `post_graph_construct`. No backend changes needed — classifications are stored free-form.
- At `post_graph_execute` (sync), the built result is reported as that node's output via `process_result`, with `realized_dependencies` set to the run's `final_vars` (captured at `pre_graph_execute`). A type check against the builder's declared output type skips the deprecated `raw_execute()`/`materialize()` paths, which fire the hook with the raw node dict without running the builder.
- `AsyncHamiltonTracker` registers the same node but reports a **status-only** update: the async driver fires `post_graph_execute` before `do_build_result`, so the built output is not observable there.
- Supporting cleanup: the attribute-shaping code triplicated across `post_node_execute` hooks is extracted into `_make_result_attributes()`, and `_extract_node_template()` is split out so the synthetic node goes through the same template path. All tracking additions are wrapped so a tracking failure can never fail the user's run.

**Frontend (`ui/frontend`)**
- `result_builder` added to the `Classification` union; nodes with it render with a dashed border and a `PiStackBold` icon in the DAG template view, a heavier dashed border in the run view, and a matching "Result Builder" legend entry.

## How I tested this

- New `ui/sdk/tests/test_result_builder_tracking.py` (5 tests): sync end-to-end tracking (node registration, classification, result summary, realized dependencies), no synthetic node when no builder is attached, failed runs emit no builder update, the `raw_execute()` guard (negative and positive path), and the async status-only path.
- Full SDK suite passes; `npm run build` for the frontend succeeds; pre-commit (ruff check/format, license headers) passes.

## Notes

Known limitations, accepted as part of approach A in the issue discussion:
- The synthetic node has no edges in the DAG-**template** view — `final_vars` are unknown at `post_graph_construct`; edges appear in the **run** view via `realized_dependencies`.
- The node's timestamps are zero-duration (builder execution time is not observable from the hooks).
- The async tracker cannot capture the built output (hook ordering, above) and reports status only.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
