### PR TITLE
Fix failing plotly CI

### DIFF
--- a/.github/workflows/hamilton-main.yml
+++ b/.github/workflows/hamilton-main.yml
@@ -85,7 +85,6 @@ jobs:
         - name: Test hamilton main package
           run: |
             uv sync --group test
-            uv pip install "kaleido<0.4.0"
             uv run pytest tests/ --cov=hamilton --ignore tests/integrations
 
 

--- a/hamilton/plugins/plotly_extensions.py
+++ b/hamilton/plugins/plotly_extensions.py
@@ -42,7 +42,7 @@ class PlotlyStaticWriter(DataSaver):
     height: int | None = None
     scale: int | float | None = None
     validate: bool = True
-    engine: str = "auto"
+    engine: str | None = None
 
     def _get_saving_kwargs(self) -> dict:
         kwargs = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ test = [
   "dlt",
   "fsspec",
   "graphviz",
-  "kaleido; python_version < '3.14'",
+  "kaleido",
   "kedro; python_version < '3.14'",
   "lancedb; python_version < '3.14'",
   "lightgbm; python_version < '3.14'",
@@ -119,7 +119,7 @@ test = [
   "networkx",
   "openpyxl", # for excel data loader
   "pandera[dask]",
-  "plotly; python_version < '3.14'",
+  "plotly",
   "polars; python_version < '3.14'",
   "pyarrow",
   "pydantic >=2.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,8 +26,6 @@ if sys.version_info >= (3, 14):
             "plugins/test_polars_extensions.py",
             "plugins/test_polars_lazyframe_extensions.py",
             "resources/narwhals_example.py",
-            # plotly - no Python 3.14 support yet
-            "plugins/test_plotly_extensions.py",
             # xgboost - no Python 3.14 support yet
             "plugins/test_xgboost_extensions.py",
             # lightgbm - no Python 3.14 support yet

--- a/tests/plugins/test_plotly_extensions.py
+++ b/tests/plugins/test_plotly_extensions.py
@@ -38,10 +38,18 @@ def test_plotly_static_writer(figure: go.Figure, tmp_path: pathlib.Path) -> None
     file_path = tmp_path / "figure.png"
 
     writer = PlotlyStaticWriter(path=file_path)
+    assert "engine" not in writer._get_saving_kwargs()
+
     metadata = writer.save_data(figure)
 
     assert file_path.exists()
     assert metadata[FILE_METADATA]["path"] == str(file_path)
+
+
+def test_plotly_static_writer_preserves_explicit_engine(tmp_path: pathlib.Path) -> None:
+    writer = PlotlyStaticWriter(path=tmp_path / "figure.png", engine="kaleido")
+
+    assert writer._get_saving_kwargs()["engine"] == "kaleido"
 
 
 def test_plotly_interactive_writer(figure: go.Figure, tmp_path: pathlib.Path) -> None:


### PR DESCRIPTION
Plotly dropped the engine in v7 that got deprecated in v6 and we had a workaround pinning Kaleido/Plotly for py<3.14

With the new changes we can drop these workaround.

## Changes

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
