### PR TITLE
Update retired Claude model id in the hamilton-llm skill

### DIFF
--- a/.claude-plugin/skills/llm/SKILL.md
+++ b/.claude-plugin/skills/llm/SKILL.md
@@ -193,7 +193,7 @@ async def llm_response__anthropic(
 ) -> str:
     """Generate with Anthropic."""
     response = await llm_client.messages.create(
-        model="claude-3-5-sonnet-20241022",
+        model="claude-sonnet-4-6",
         max_tokens=1024,
         messages=[{"role": "user", "content": prompt}]
     )


### PR DESCRIPTION
The Anthropic branch of the provider-switching example in the `hamilton-llm` skill names a model id the API stopped serving on 28 October 2025, per the [Anthropic deprecations page](https://platform.claude.com/docs/en/about-claude/model-deprecations).

| File | Line | Was | Now |
| --- | --- | --- | --- |
| `.claude-plugin/skills/llm/SKILL.md` | 196 | `claude-3-5-sonnet-20241022` | `claude-sonnet-4-6` |

`claude-sonnet-4-6` is the current Sonnet, which keeps the example in the same tier it was written for. The `gpt-4` id in the OpenAI branch a few lines up is still served, so I left it alone.

That is the only retired Claude id in the repository. The rest of `.claude-plugin` and the `hamilton` package itself do not pin an Anthropic model.

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. I have not run the example against the API to reproduce a failure, the claim rests on the published retirement date. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
