### PR TITLE
Flush buffered events before the async tracking client's worker exits

### DIFF
--- a/ui/sdk/src/hamilton_sdk/adapters.py
+++ b/ui/sdk/src/hamilton_sdk/adapters.py
@@ -469,6 +469,14 @@ class AsyncHamiltonTracker(
         self.initialized = True
         return self
 
+    async def stop(self):
+        """Flush any buffered tracking data and stop the background worker.
+
+        Call this before your event loop shuts down; nothing else flushes
+        the tracker's queue for you.
+        """
+        await self.client.stop()
+
     async def post_graph_construct(
         self, graph: h_graph.FunctionGraph, modules: list[ModuleType], config: dict[str, Any]
     ):

--- a/ui/sdk/src/hamilton_sdk/api/clients.py
+++ b/ui/sdk/src/hamilton_sdk/api/clients.py
@@ -585,9 +585,24 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
         self.data_queue = asyncio.Queue()
         self.running = True
         self.max_batch_size = 100
+        self.worker_task: asyncio.Task | None = None
 
     async def ainit(self):
-        asyncio.create_task(self.worker())
+        self.worker_task = asyncio.create_task(self.worker())
+
+    async def stop(self):
+        """Signal the worker to flush whatever is buffered and exit.
+
+        Unlike BasicSynchronousHamiltonClient, this is not wired to atexit:
+        the worker is a task on this event loop, and by the time atexit
+        callbacks run at interpreter shutdown the loop may already be
+        closed, so callers must await this explicitly before the loop
+        that owns it stops running.
+        """
+        if self.worker_task is None or self.worker_task.done():
+            return
+        await self.data_queue.put(None)
+        await self.worker_task
 
     async def flush(self, batch):
         """Flush the batch (send it to the backend or process it)."""
@@ -624,7 +639,6 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
             )
             try:
                 item = await asyncio.wait_for(self.data_queue.get(), timeout=self.flush_interval)
-                batch.append(item)
             except asyncio.TimeoutError:
                 # This is fine, we just keep waiting
                 pass
@@ -632,6 +646,7 @@ class BasicAsynchronousHamiltonClient(HamiltonClient):
                 if item is None:
                     await self.flush(batch)
                     return
+                batch.append(item)
 
             # Check if batch is full or flush interval has passed
             if (

--- a/ui/sdk/tests/test_adapters.py
+++ b/ui/sdk/tests/test_adapters.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import asyncio
 import os.path
 
 import pytest
@@ -160,6 +161,32 @@ def test_parallel_ray_sample_error():
         dr.execute(final_vars=["statistics_by_city"], inputs={"data_dir": data_dir})
     if shutdown:
         shutdown()
+
+
+def test_async_hamilton_tracker_stop_delegates_to_client():
+    """Regression for #1214: AsyncHamiltonTracker had no way for a caller to
+    flush its client's buffered tracking data before the event loop shuts
+    down. stop() must delegate to the underlying client's stop()."""
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            self.stop_calls = 0
+
+        async def stop(self):
+            self.stop_calls += 1
+
+    async def run():
+        tracker = adapters.AsyncHamiltonTracker(
+            project_id=1,
+            username="test-user",
+            dag_name="test-dag",
+            client_factory=_FakeAsyncClient,
+            api_key="test-key",
+        )
+        await tracker.stop()
+        assert tracker.client.stop_calls == 1
+
+    asyncio.run(run())
 
 
 if __name__ == "__main__":

--- a/ui/sdk/tests/test_clients.py
+++ b/ui/sdk/tests/test_clients.py
@@ -81,3 +81,48 @@ def test_async_flush_succeeds_on_2xx():
             await client.flush(batch)
 
     asyncio.run(run())
+
+
+def test_async_client_stop_flushes_buffered_item_and_exits_worker():
+    """Regression for #1214: worker()'s only exit path waits for a `None`
+    sentinel on data_queue, and nothing ever put one there for the async
+    client, so a buffered item sat unflushed until the flush_interval timer
+    happened to fire, or was lost outright if the process exited first.
+    stop() must send that sentinel and wait for the worker to flush and
+    exit, well before the flush_interval timeout."""
+
+    async def run():
+        client = _make_client()
+        session_cm = _mock_session_with_status(200)
+        with patch("aiohttp.ClientSession", return_value=session_cm):
+            await client.ainit()
+            await client.update_tasks(dag_run_id=1, attributes=[], task_updates=[])
+
+            assert not client.worker_task.done()
+
+            await client.stop()
+
+            assert client.worker_task.done()
+            assert client.data_queue.empty()
+            session_cm.__aenter__.return_value.put.assert_called_once()
+
+    asyncio.run(run())
+
+
+def test_async_client_stop_is_idempotent():
+    async def run():
+        client = _make_client()
+        with patch("aiohttp.ClientSession", return_value=_mock_session_with_status(200)):
+            await client.ainit()
+            await client.stop()
+            await client.stop()  # must not hang or raise
+
+    asyncio.run(run())
+
+
+def test_async_client_stop_before_ainit_is_a_noop():
+    async def run():
+        client = _make_client()
+        await client.stop()  # worker_task is None, must not raise
+
+    asyncio.run(run())


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

Fixes #1214.

## Changes

`BasicAsynchronousHamiltonClient` (`ui/sdk/src/hamilton_sdk/api/clients.py`) had no `stop()`
and registered no atexit hook, unlike its synchronous sibling. `worker()`'s only exit path
waits for a `None` sentinel on `data_queue`, and nothing ever put one there for the async
client, so a buffered batch sat until the periodic flush timer happened to catch it, or was
lost outright if the process (or the event loop that owned the worker task) exited first.

- Added `async def stop()` on `BasicAsynchronousHamiltonClient`: sends the sentinel and awaits
  the worker task so it flushes and exits. This is not wired to `atexit`, deliberately: the
  worker is a task on the caller's event loop, and by the time atexit callbacks run at
  interpreter shutdown that loop may already be closed, so callers must await `stop()`
  themselves before the loop stops running (mirroring the sync client isn't possible here for
  that reason; happy to add an `atexit`-scheduled best-effort variant too if maintainers want
  one, but that has its own shutdown-ordering edge cases worth discussing first).
- Added the matching `async def stop()` on `AsyncHamiltonTracker` (`adapters.py`), delegating
  to the client.
- Fixed a bug in `worker()`'s sentinel handling that this exercises for the first time: it
  appended the received item to `batch` before checking whether it was the `None` sentinel, so
  the first real `stop()` call flushed a batch containing `None` and raised. Reordered to check
  first, matching the synchronous client's worker.

## How I tested this

Ran in a clean `python:3.13-slim` and `python:3.10-slim` Docker container (the SDK's CI matrix
runs 3.10-3.14; I could not run the 3.11/3.12/3.14 legs locally but the change has no
version-specific code paths):

- New regression tests in `tests/test_clients.py` and `tests/test_adapters.py`: fail with
  `AttributeError` on unmodified `main` (confirmed via `git stash`), pass on this branch.
  `test_async_client_stop_flushes_buffered_item_and_exits_worker` enqueues an item, calls
  `stop()` before the flush interval elapses, and asserts the mocked backend request actually
  fired and the queue drained; it caught the sentinel-ordering bug above on first run.
- Full `pytest tests/` (minus the `ray`/`pyspark`-gated tests, which are `pytest.importorskip`
  guarded and unrelated to this change): 140 passed, 5 skipped, no failures.
- `ruff check` and `ruff format --diff` on the four changed files: clean. This repo's CI does
  not run a lint/static-checks job for `ui/sdk`-only changes (checked `gh pr checks` on a
  recently merged `ui/sdk`-only PR, #1626), so this was a courtesy check, not a required gate.

Not verified: behavior under a real ASGI/FastAPI shutdown sequence (e.g. the app in
`examples/async/fastapi_example.py`, which doesn't call the new `stop()` either); the fix is
scoped to the tracker itself, not to updating that example.
