### PR TITLE
Fix paths to developer_setup.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ ipython_config.py
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
 #Pipfile.lock
+uv.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Additionally, the code should follow any stylistic and architectural guidelines
 prescribed by the project. For us here, this means you install a pre-commit hook and use
 the given style files. Basically, you should mimic the styles and patterns in the Apache Hamilton code-base.
 
-In terms of getting setup to develop, we invite you to read our [developer setup guide](developer_setup.md).
+In terms of getting setup to develop, we invite you to read our [developer setup guide](writeups/developer_setup.md).
 
 ## Using circleci CLI to run tests locally
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Apache Hamilton is released under the Apache 2.0 License. See [LICENSE](https://
 ## 👨‍💻 Contributing
 We're very supportive of changes by new contributors, big or small! Make sure to discuss potential changes by creating an issue or commenting on an existing one before opening a pull request. Good first contributions include creating an example or an integration with your favorite Python library!
 
- To contribute, checkout our [contributing guidelines](https://github.com/apache/hamilton/blob/main/CONTRIBUTING.md), our [developer setup guide](https://github.com/apache/hamilton/blob/main/developer_setup.md), and our [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
+ To contribute, checkout our [contributing guidelines](https://github.com/apache/hamilton/blob/main/CONTRIBUTING.md), our [developer setup guide](https://github.com/apache/hamilton/blob/main/writeups/developer_setup.md), and our [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
 
 
 ## 😎 Used by


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

The README and CONTRIBUTING appear to include outdated links to the developer setup guide. 

## Changes

Update paths in README.md and CONTRIBUTING.md to point to `writeups/developer_setup.md`. 

## How I tested this

No code tests needed, pre-commit passed. Checked the link works when viewing the files in GitHub.

## Notes

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
